### PR TITLE
Feature/timelapse

### DIFF
--- a/src/commons/plantimager/commons/RPC.py
+++ b/src/commons/plantimager/commons/RPC.py
@@ -22,6 +22,7 @@ import copy
 import inspect
 import json
 import logging
+import os
 import re
 import sys
 import time
@@ -664,7 +665,7 @@ class RPCClient:
             if receiver:
                 receiver.stop()
                 receiver.join(2)
-            logger.debug("Client finalized")
+            if os.getenv("PI_LOG_FINALIZE") : logger.info("RPCClient finalized")
 
         finalize(self, _finalizer, self.socket, self._signal_receiver)
 
@@ -1016,7 +1017,7 @@ class RPCServer:
             state["socket"].close()
             if state["signal_socket"]:
                 state["signal_socket"].close()
-            logger.info("Server deleted")
+            if os.getenv("PI_LOG_FINALIZE"): logger.info("RPCServer finalized")
 
         finalize(self, _server_finalizer, self._cleanup_state, self._signals)
 

--- a/src/commons/plantimager/commons/controller_device.py
+++ b/src/commons/plantimager/commons/controller_device.py
@@ -44,6 +44,26 @@ class ControllerDevice(ABC):
         """Start the scan."""
         pass
 
+    @abstractmethod
+    def start_timelapse(self, config: dict) -> str:
+        """Create and start a timelapse from a configuration dict."""
+        pass
+
+    @abstractmethod
+    def get_active_timelapse(self) -> dict | None:
+        """Return a serialisable snapshot of the active timelapse, or None."""
+        pass
+
+    @abstractmethod
+    def cancel_timelapse(self):
+        """Cancel the active timelapse."""
+        pass
+
+    @abstractmethod
+    def preview_timelapse(self, config: dict) -> dict:
+        """Return the schedule computed for a config, without starting it."""
+        pass
+
     @RPCProperty(notify=progressChanged)
     @abstractmethod
     def progress(self) -> int:

--- a/src/controller/plantimager/controller/camera/PiCameraComm.py
+++ b/src/controller/plantimager/controller/camera/PiCameraComm.py
@@ -1,3 +1,4 @@
+import os
 import weakref
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
@@ -65,6 +66,7 @@ class PiCameraComm(QObject):
             pool.shutdown(wait=False)
             if camera:
                 camera.stop_server()
+            if os.getenv("PI_LOG_FINALIZE"): logger.info("PiCameraComm finalized")
 
         finalize(self, _finalizer, self._thread_pool, self._camera)
 

--- a/src/controller/plantimager/controller/scanner/dummy_cnc.py
+++ b/src/controller/plantimager/controller/scanner/dummy_cnc.py
@@ -77,7 +77,10 @@ class DummyCNC(AbstractCNC):
 
         # Simulate initialization delay
         time.sleep(0.2)
+        self._ready = True
+        self._standby = True
         logger.info("Dummy CNC initialized")
+
 
     def _check_move(self, x: float, y: float, z: float) -> None:
         """Validate that the requested movement coordinates are within the machine's axis limits.
@@ -107,6 +110,7 @@ class DummyCNC(AbstractCNC):
         Sets the current position to a starting point near the origin,
         simulating the behavior of the real CNC homing procedure.
         """
+        self._standby = False
         logger.info("Dummy CNC homing...")
         self._busy = True
         # Simulate homing time
@@ -115,6 +119,7 @@ class DummyCNC(AbstractCNC):
         self._position = (20, 20, 0)
         self._busy = False
         logger.info("Dummy CNC homing completed")
+        self._standby = True
 
     def get_position(self) -> tuple[length_mm, length_mm, deg]:
         """Get the current XYZ position of the dummy CNC machine.
@@ -156,8 +161,10 @@ class DummyCNC(AbstractCNC):
         ValueError
             If any of the target coordinates are outside the allowed limits
         """
+        self._standby = False
         self.moveto_async(x, y, z)
         self.wait()
+        self._standby = True
 
     def moveto_async(self, x: length_mm, y: length_mm, z: deg) -> None:
         """Asynchronously move the dummy CNC machine to specified coordinates.

--- a/src/controller/plantimager/controller/scanner/grbl.py
+++ b/src/controller/plantimager/controller/scanner/grbl.py
@@ -219,12 +219,14 @@ class CNC(AbstractCNC):
         # Clear input buffer
         self.serial_port.flushInput()
 
-        # Apply all GRBL configuration settings from a predefined dictionary
-        for code, (_, _, value) in GRBL_SETTINGS.items():
-            self.send_cmd(f"{code}={value}", wait=True, timeout=1)
-
         # Get current GRBL settings
         self.grbl_settings = self.get_grbl_settings()
+
+        # Apply all GRBL configuration settings from a predefined dictionary
+        for code, (_, _, value) in GRBL_SETTINGS.items():
+            if self.grbl_settings[code] != value:
+                self.send_cmd(f"{code}={value}", wait=True, timeout=1)
+
 
         # Parse direction port invert mask (setting $3) to determine axis inversions
         invert_mask = self.grbl_settings["$3"]

--- a/src/controller/plantimager/controller/scanner/grbl.py
+++ b/src/controller/plantimager/controller/scanner/grbl.py
@@ -178,6 +178,7 @@ class CNC(AbstractCNC):
         self.grbl_settings = None
         self._start()
         finalize(self, self.stop)
+        self._ready, self._standby = True, True
 
     def _start(self) -> None:
         """Initialize the serial connection with Arduino and configure the GRBL-based CNC machine.
@@ -432,6 +433,8 @@ class CNC(AbstractCNC):
         - GRBL Homing Cycle: https://github.com/gnea/grbl/wiki/Grbl-v1.1-Commands#h---run-homing-cycle
         - ``G92`` Reference: http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g92
         """
+        prior_ready_state = self.ready
+        self._standby = False
         # Execute GRBL homing cycle to find machine zero
         self.send_cmd("$H", wait=True, timeout=60)
 
@@ -453,6 +456,7 @@ class CNC(AbstractCNC):
         y_init = sign_y * (y_max - pulloff) if pulloff_mask & 2 else sign_y * pulloff
         z_init = sign_z * (z_max - pulloff) if pulloff_mask & 4 else sign_z * pulloff
         self.send_cmd(f"g92 x{x_init} y{y_init} z{z_init}", wait=True, timeout=10)
+        self._standby = prior_ready_state
 
     def _check_move(self, x: float, y: float, z: float) -> None:
         """Validate that the requested movement coordinates are within the machine's axis limits.
@@ -505,6 +509,7 @@ class CNC(AbstractCNC):
         - Units are in millimeters (``G21`` mode)
         - The method will block until the movement is complete
         """
+        self._standby = False
         # Validate that the target coordinates are within machine limits
         self._check_move(x, y, z)
 
@@ -528,6 +533,7 @@ class CNC(AbstractCNC):
         if time.time() - t0 < travel_time:
             time.sleep(travel_time - (time.time() - t0))
         self.wait_until_immobile(30)
+        self._standby = True
 
     def moveto_async(self, x: length_mm, y: length_mm, z: deg) -> bytes:
         """Asynchronously move the CNC machine to specified coordinates using G0 rapid positioning.

--- a/src/controller/plantimager/controller/scanner/hal.py
+++ b/src/controller/plantimager/controller/scanner/hal.py
@@ -15,7 +15,7 @@ Key Features:
 - Standardized data formats for database storage
 """
 
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod, abstractproperty
 from typing import List, Tuple, Union
 
 import numpy as np
@@ -50,7 +50,8 @@ class AbstractCNC(metaclass=ABCMeta):
     """Abstract CNC class."""
 
     def __init__(self):
-        pass
+        self._ready = False
+        self._standby = False
 
     @abstractmethod
     def home(self) -> None:
@@ -71,3 +72,14 @@ class AbstractCNC(metaclass=ABCMeta):
     @abstractmethod
     def wait(self) -> None:
         pass
+
+    @property
+    def ready(self) -> bool:
+        """Returns True if the hardware component is ready to be used"""
+        return self._ready
+
+    @property
+    def standby(self) -> bool:
+        """Returns True if the hardware component is on standby."""
+        return self._standby
+

--- a/src/controller/plantimager/controller/scanner/powermanager.py
+++ b/src/controller/plantimager/controller/scanner/powermanager.py
@@ -2,43 +2,153 @@
 Manages the switching on and off of the various components of the scanner via the GPIO
 """
 import os
+import inspect
+from typing import Callable
+from functools import update_wrapper
 
-from PySide6.QtCore import QObject, Signal, Slot, Property
+import serial
+from PySide6.QtCore import QObject, Signal, Slot, Property, QTimer
 import gpio
 
 from plantimager.controller.scanner.grbl import CNC
 
+GPIO_CNC_PIN = int(os.getenv("GPIO_CNC_PIN", 17))
+GPIO_LIGHTS_PIN = int(os.getenv("GPIO_LIGHTS_PIN", 27))
+GPIO_GROWTH_LIGHTS_PIN = int(os.getenv("GPIO_GROWTH_LIGHTS_PIN", 22))
+
+
+def activity_monitor(obj: object, callback: Callable[[], None]):
+    """
+    Wraps all methods of the given `obj` to trigger a specified callback before executing
+    the original method. This is useful for monitoring or observing object activity, such
+    as logging or tracking method calls.
+
+    This function dynamically intercepts all methods of the input `obj` object and wraps
+    them such that the `callback` function is executed prior to the method's actual
+    invocation. The wrapped methods retain their arguments, return values, and
+    attributes.
+
+    Parameters
+    ----------
+    obj : object
+        The target object whose methods are to be monitored. All methods of this object
+        will be wrapped to include the `callback`.
+    callback : Callable[[], None]
+        A zero-argument callable that is executed before any method of `obj` is invoked.
+
+    Returns
+    -------
+    object
+        The original `obj`, with its methods wrapped to call `callback` before
+        execution.
+
+    Raises
+    ------
+    AttributeError
+        If an attribute of `obj` cannot be fetched or set while wrapping methods.
+
+    Notes
+    -----
+    The `callback` function is expected to handle side-effects or monitoring concerns
+    (e.g., logging, notifications). This function does not guarantee thread safety if
+    the `obj`'s methods are accessed simultaneously from multiple threads.
+
+    See Also
+    --------
+    functools.update_wrapper : Used internally to update the wrapped function's
+        metadata to match the original function.
+
+    Examples
+    --------
+    >>> from functools import partial
+    >>> class MyClass:
+    ...     def method(self, x):
+    ...         print(f'Method called with {x}')
+    >>> obj = MyClass()
+    >>> def my_callback():
+    ...     print('Callback triggered!')
+    >>> monitored_obj = activity_monitor(obj, my_callback)
+    >>> monitored_obj.method(10)
+    Callback triggered!
+    Method called with 10
+    """
+    for attr in dir(obj):
+        if inspect.ismethod(getattr(obj, attr)):
+            original_method = getattr(obj, attr)
+
+            def f(*args, **kwargs):
+                callback()
+                original_method(*args, **kwargs)
+            setattr(obj, attr, update_wrapper(f, original_method))
+    return obj
 
 class PowerManager(QObject):
 
+    cnc: CNC | None
+    cnc_ready = Signal(CNC)
+
     def __init__(self, warmup_period: int, parent=None):
         super().__init__(parent)
+        gpio.setup(
+            (GPIO_CNC_PIN, GPIO_LIGHTS_PIN, GPIO_GROWTH_LIGHTS_PIN),
+            mode=gpio.OUT,
+            initial=gpio.LOW
+        )
+        self.lights_power_on()
+        self.cnc = None
+        self.cnc_timer = QTimer(parent=self, singleShot=True, interval=60*5*1000)  # 5 minutes in ms
+        self.cnc_timer.timeout.connect(self.cnc_power_off)
+        self.cnc_connect_timer = QTimer(parent=self, singleShot=False, interval=1200)
+        self.cnc_connect_timer.timeout.connect(self._cnc_connect)
 
+    @Slot
+    def _cnc_connect(self):
+        try:
+            if self.cnc is None: self.cnc = CNC()
+        except serial.SerialException:
+            return
+        except RuntimeError:
+            return
+        else:
+            activity_monitor(self.cnc, self.cnc_timer.start)
+            self.cnc_connect_timer.stop()
+            self.cnc_timer.start()
+            self.cnc_ready.emit(self.cnc)
+
+    @Slot
     def cnc_power_on(self):
-        pass
-        self.cnc = CNC()
-        self.cnc.moveto(20, 20, 45)
+        gpio.write(GPIO_CNC_PIN, True)
+        self.cnc_connect_timer.start()
 
+    @Slot
     def cnc_power_off(self):
-        pass
+        self.cnc.stop()
+        self.cnc_timer.stop()
+        self.cnc_timer.timeout.disconnect(slot=self.cnc_power_off)
+        self.cnc = None
+        gpio.write(GPIO_CNC_PIN, False)
 
+    @Slot
     def lights_power_on(self):
-        pass
+        gpio.write(GPIO_LIGHTS_PIN, True)
 
+    @Slot
     def lights_power_off(self):
-        pass
+        gpio.write(GPIO_LIGHTS_PIN, True)
 
+    @Slot
     def glights_power_on(self):
-        pass
+        gpio.write(GPIO_GROWTH_LIGHTS_PIN, True)
 
+    @Slot
     def glights_power_off(self):
-        pass
+        gpio.write(GPIO_GROWTH_LIGHTS_PIN, True)
 
+    @Slot
     def prepare_for_scan(self):
         self.cnc_power_on()
         self.lights_power_on()
         self.glights_power_off()
 
     def get_cnc(self):
-
         return self.cnc

--- a/src/controller/plantimager/controller/scanner/powermanager.py
+++ b/src/controller/plantimager/controller/scanner/powermanager.py
@@ -1,0 +1,44 @@
+"""
+Manages the switching on and off of the various components of the scanner via the GPIO
+"""
+import os
+
+from PySide6.QtCore import QObject, Signal, Slot, Property
+import gpio
+
+from plantimager.controller.scanner.grbl import CNC
+
+
+class PowerManager(QObject):
+
+    def __init__(self, warmup_period: int, parent=None):
+        super().__init__(parent)
+
+    def cnc_power_on(self):
+        pass
+        self.cnc = CNC()
+        self.cnc.moveto(20, 20, 45)
+
+    def cnc_power_off(self):
+        pass
+
+    def lights_power_on(self):
+        pass
+
+    def lights_power_off(self):
+        pass
+
+    def glights_power_on(self):
+        pass
+
+    def glights_power_off(self):
+        pass
+
+    def prepare_for_scan(self):
+        self.cnc_power_on()
+        self.lights_power_on()
+        self.glights_power_off()
+
+    def get_cnc(self):
+
+        return self.cnc

--- a/src/controller/plantimager/controller/scanner/powermanager.py
+++ b/src/controller/plantimager/controller/scanner/powermanager.py
@@ -3,6 +3,7 @@ Manages the switching on and off of the various components of the scanner via th
 """
 import os
 import inspect
+from enum import StrEnum
 from typing import Callable
 from functools import update_wrapper
 
@@ -10,7 +11,10 @@ import serial
 from PySide6.QtCore import QObject, Signal, Slot, Property, QTimer
 import gpio
 
+from plantimager.commons.logging import create_logger
 from plantimager.controller.scanner.grbl import CNC
+
+logger = create_logger(__name__)
 
 GPIO_CNC_PIN = int(os.getenv("GPIO_CNC_PIN", 17))
 GPIO_LIGHTS_PIN = int(os.getenv("GPIO_LIGHTS_PIN", 27))
@@ -82,10 +86,15 @@ def activity_monitor(obj: object, callback: Callable[[], None]):
             setattr(obj, attr, update_wrapper(f, original_method))
     return obj
 
+class PowerManagerMode(StrEnum):
+    SCAN = "scan"
+    AUTO = "auto"  # automatic light schedule
+
 class PowerManager(QObject):
 
     cnc: CNC | None
     cnc_ready = Signal(CNC)
+    modeChanged = Signal(str)
 
     def __init__(self, warmup_period: int, parent=None):
         super().__init__(parent)
@@ -100,6 +109,8 @@ class PowerManager(QObject):
         self.cnc_timer.timeout.connect(self.cnc_power_off)
         self.cnc_connect_timer = QTimer(parent=self, singleShot=False, interval=1200)
         self.cnc_connect_timer.timeout.connect(self._cnc_connect)
+        self._mode: PowerManagerMode = PowerManagerMode.AUTO
+        self.modeChanged.connect(self._on_mode_changed)
 
     @Slot
     def _cnc_connect(self):
@@ -144,11 +155,37 @@ class PowerManager(QObject):
     def glights_power_off(self):
         gpio.write(GPIO_GROWTH_LIGHTS_PIN, True)
 
-    @Slot
-    def prepare_for_scan(self):
+    @Property(str, notify=modeChanged)
+    def mode(self) -> PowerManagerMode:
+        return self._mode
+    @mode.setter
+    def mode(self, mode: PowerManagerMode):
+        if self._mode != mode:
+            self._mode = mode
+            self.modeChanged.emit(mode)
+
+    @Slot(str)
+    def _on_mode_changed(self, mode):
+        if mode == PowerManagerMode.AUTO:
+            self._resume_auto()
+        elif mode == PowerManagerMode.SCAN:
+            self._prepare_for_scan()
+        else:
+            logger.error(f"Unknown mode: {mode}")
+
+    def _prepare_for_scan(self):
         self.cnc_power_on()
         self.lights_power_on()
         self.glights_power_off()
 
+    def _resume_auto(self):
+        self.cnc_power_on()
+        self.lights_power_off()
+        self.glights_power_on()
+
     def get_cnc(self):
         return self.cnc
+
+    def set_light_policy(self, policy: dict):
+        # For future automatic light management
+        pass

--- a/src/controller/plantimager/controller/scanner/powermanager.py
+++ b/src/controller/plantimager/controller/scanner/powermanager.py
@@ -2,6 +2,7 @@
 Manages the switching on and off of the various components of the scanner via the GPIO
 """
 import os
+import datetime
 import inspect
 from enum import StrEnum
 from typing import Callable
@@ -13,6 +14,7 @@ import gpio
 
 from plantimager.commons.logging import create_logger
 from plantimager.controller.scanner.grbl import CNC
+from plantimager.controller.scanner.hal import AbstractCNC
 
 logger = create_logger(__name__)
 
@@ -89,6 +91,7 @@ def activity_monitor(obj: object, callback: Callable[[], None]):
 class PowerManagerMode(StrEnum):
     SCAN = "scan"
     AUTO = "auto"  # automatic light schedule
+    MANUAL = "manual"
 
 class PowerManager(QObject):
 
@@ -96,70 +99,164 @@ class PowerManager(QObject):
     cnc_ready = Signal(CNC)
     modeChanged = Signal(str)
 
-    def __init__(self, warmup_period: int, parent=None):
+    def __init__(self, warmup_period: float, parent=None):
+        """
+        Initialize the PowerManager instance.
+
+        This class provides control over the power management system, including
+        handling CNC connections, light toggling, and manual/automatic power
+        management modes. It relies on GPIO for hardware interactions and provides
+        timing mechanisms to manage various operations.
+
+        Parameters
+        ----------
+        warmup_period : float
+            The duration (in seconds) required for components to warm up before a
+            specific operation.
+        parent : optional
+            The parent QObject for the timers created within the object. Defaults
+            to ``None``.
+
+        Attributes
+        ----------
+        cnc : AbstractCNC or None
+            Represents the CNC connection object. Defaults to ``None`` until an
+            active connection is established.
+        warmup_period : float
+            The configured warmup period (in seconds).
+        manual_mode_timer : QTimer
+            A single-shot timer used to manage the manual mode timeout. It triggers
+            after 5 minutes (converted to milliseconds).
+        cnc_connect_timer : QTimer
+            A regular timer used to periodically attempt CNC reconnections. It is
+            triggered every 1.2 seconds (1200 milliseconds).
+        _mode : PowerManagerMode
+            Tracks the current power management mode. Defaults to
+            ``PowerManagerMode.AUTO``.
+        _next_warmup_date : datetime.datetime or None
+            Holds the date and time of the next warmup operation. Defaults to ``None``.
+        """
         super().__init__(parent)
         gpio.setup(
             (GPIO_CNC_PIN, GPIO_LIGHTS_PIN, GPIO_GROWTH_LIGHTS_PIN),
             mode=gpio.OUT,
             initial=gpio.LOW
         )
-        self.lights_power_on()
-        self.cnc = None
-        self.cnc_timer = QTimer(parent=self, singleShot=True, interval=60*5*1000)  # 5 minutes in ms
-        self.cnc_timer.timeout.connect(self.cnc_power_off)
+        self.cnc: AbstractCNC | None = None
+        self.warmup_period: float = warmup_period
+        self.manual_mode_timer = QTimer(parent=self, singleShot=True, interval=60 * 5 * 1000)  # 5 minutes in ms
+        self.manual_mode_timer.timeout.connect(self._manual_mode_timeout)
         self.cnc_connect_timer = QTimer(parent=self, singleShot=False, interval=1200)
         self.cnc_connect_timer.timeout.connect(self._cnc_connect)
         self._mode: PowerManagerMode = PowerManagerMode.AUTO
         self.modeChanged.connect(self._on_mode_changed)
+        self._next_warmup_date: datetime.datetime | None = None
+        self._resume_auto()
 
     @Slot()
     def _cnc_connect(self):
+        """
+        Establishes a connection to the CNC machine and configures its operational state.
+
+        This method initializes and connects to a CNC machine instance if it is not
+        already connected. It handles exceptions related to communication issues
+        during the initialization process, ensures timers associated with CNC modes
+        are started, and emits a signal indicating the CNC machine is ready.
+
+        Notes
+        -----
+        - If an instance of the CNC machine (`self.cnc`) is already initialized, this method
+          does not reinitialize it.
+
+        See Also
+        --------
+        activity_monitor : Monitors CNC activity for logging and synchronization purposes.
+
+        """
+        if isinstance(self.cnc, CNC):
+            self.cnc_connect_timer.stop()
+            return
+
         try:
             if self.cnc is None: self.cnc = CNC()
         except serial.SerialException:
             return
         except RuntimeError:
             return
+
+        self.cnc_connect_timer.stop()
+        if self._mode == PowerManagerMode.MANUAL:
+            activity_monitor(self.cnc, self.manual_mode_timer.start)
+            self.manual_mode_timer.start()
+        self.cnc_ready.emit(self.cnc)
+
+    @Slot()
+    def _manual_mode_timeout(self):
+        """
+        Handles the timeout event for manual mode, switching modes based on
+        the current time and warmup status.
+
+        This method stops the manual mode timer and updates the power manager
+        mode based on the presence of a warmup date and the time elapsed since
+        `self._next_warmup_date`. Depending on the conditions met, the mode is
+        set to either `SCAN` or `AUTO`.
+
+        Notes
+        -----
+        - `self._next_warmup_date` must be a `datetime` object or `None`.
+        - The `warmup_period` is used to determine mode-switching logic based
+          on the time difference.
+        - This private method is intended to be used internally within the system
+          and is not part of a public API.
+
+        Raises
+        ------
+        AttributeError
+            If `self._next_warmup_date` or `self.warmup_period` is not properly
+            initialized as expected.
+        """
+        self.manual_mode_timer.stop()
+
+        if self._next_warmup_date is None:
+            self.mode = PowerManagerMode.AUTO
+            return
+
+        now = datetime.datetime.now()
+        logger.debug(f"{self._next_warmup_date - now} -- {datetime.timedelta(seconds=self.warmup_period + 1.)}")
+        if self._next_warmup_date - now < datetime.timedelta(seconds=self.warmup_period + 1.):
+            self.mode = PowerManagerMode.SCAN
         else:
-            activity_monitor(self.cnc, self.cnc_timer.start)
-            self.cnc_connect_timer.stop()
-            self.cnc_timer.start()
-            self.cnc_ready.emit(self.cnc)
+            self.mode = PowerManagerMode.AUTO
 
-    @Slot()
-    def cnc_power_on(self):
+
+    def _cnc_power_on(self):
         gpio.write(GPIO_CNC_PIN, True)
-        self.cnc_connect_timer.start()
 
-    @Slot()
-    def cnc_power_off(self):
+    def _cnc_power_off(self):
         self.cnc.stop()
-        self.cnc_timer.stop()
-        self.cnc_timer.timeout.disconnect(slot=self.cnc_power_off)
         self.cnc = None
         gpio.write(GPIO_CNC_PIN, False)
 
-    @Slot()
-    def lights_power_on(self):
+    def _lights_power_on(self):
         gpio.write(GPIO_LIGHTS_PIN, True)
 
-    @Slot()
-    def lights_power_off(self):
-        gpio.write(GPIO_LIGHTS_PIN, True)
+    def _lights_power_off(self):
+        gpio.write(GPIO_LIGHTS_PIN, False)
 
-    @Slot()
-    def glights_power_on(self):
+    def _glights_power_on(self):
         gpio.write(GPIO_GROWTH_LIGHTS_PIN, True)
 
-    @Slot()
-    def glights_power_off(self):
-        gpio.write(GPIO_GROWTH_LIGHTS_PIN, True)
+    def _glights_power_off(self):
+        gpio.write(GPIO_GROWTH_LIGHTS_PIN, False)
 
     @Property(str, notify=modeChanged)
     def mode(self) -> PowerManagerMode:
         return self._mode
     @mode.setter
     def mode(self, mode: PowerManagerMode):
+        if mode == PowerManagerMode.MANUAL and self._mode == PowerManagerMode.SCAN:
+            logger.warning("Cannot transition to MANUAL mode from SCAN mode.")
+            return
         if self._mode != mode:
             self._mode = mode
             self.modeChanged.emit(mode)
@@ -170,18 +267,20 @@ class PowerManager(QObject):
             self._resume_auto()
         elif mode == PowerManagerMode.SCAN:
             self._prepare_for_scan()
+        elif mode == PowerManagerMode.MANUAL:
+            self._prepare_for_scan()
         else:
             logger.error(f"Unknown mode: {mode}")
 
     def _prepare_for_scan(self):
-        self.cnc_power_on()
-        self.lights_power_on()
-        self.glights_power_off()
+        self._cnc_power_on()
+        self._lights_power_on()
+        self._glights_power_off()
 
     def _resume_auto(self):
-        self.cnc_power_on()
-        self.lights_power_off()
-        self.glights_power_on()
+        self._cnc_power_on()
+        self._lights_power_off()
+        self._glights_power_on()
 
     def get_cnc(self):
         return self.cnc
@@ -189,3 +288,6 @@ class PowerManager(QObject):
     def set_light_policy(self, policy: dict):
         # For future automatic light management
         pass
+
+    def set_next_auto_warmup_date(self, date: datetime.datetime):
+        self._next_warmup_date = date

--- a/src/controller/plantimager/controller/scanner/powermanager.py
+++ b/src/controller/plantimager/controller/scanner/powermanager.py
@@ -112,7 +112,7 @@ class PowerManager(QObject):
         self._mode: PowerManagerMode = PowerManagerMode.AUTO
         self.modeChanged.connect(self._on_mode_changed)
 
-    @Slot
+    @Slot()
     def _cnc_connect(self):
         try:
             if self.cnc is None: self.cnc = CNC()
@@ -126,12 +126,12 @@ class PowerManager(QObject):
             self.cnc_timer.start()
             self.cnc_ready.emit(self.cnc)
 
-    @Slot
+    @Slot()
     def cnc_power_on(self):
         gpio.write(GPIO_CNC_PIN, True)
         self.cnc_connect_timer.start()
 
-    @Slot
+    @Slot()
     def cnc_power_off(self):
         self.cnc.stop()
         self.cnc_timer.stop()
@@ -139,19 +139,19 @@ class PowerManager(QObject):
         self.cnc = None
         gpio.write(GPIO_CNC_PIN, False)
 
-    @Slot
+    @Slot()
     def lights_power_on(self):
         gpio.write(GPIO_LIGHTS_PIN, True)
 
-    @Slot
+    @Slot()
     def lights_power_off(self):
         gpio.write(GPIO_LIGHTS_PIN, True)
 
-    @Slot
+    @Slot()
     def glights_power_on(self):
         gpio.write(GPIO_GROWTH_LIGHTS_PIN, True)
 
-    @Slot
+    @Slot()
     def glights_power_off(self):
         gpio.write(GPIO_GROWTH_LIGHTS_PIN, True)
 

--- a/src/controller/plantimager/controller/scanner/powermanager.py
+++ b/src/controller/plantimager/controller/scanner/powermanager.py
@@ -26,66 +26,24 @@ GPIO_GROWTH_LIGHTS_PIN = int(os.getenv("GPIO_GROWTH_LIGHTS_PIN", 22))
 def activity_monitor(obj: object, callback: Callable[[], None]):
     """
     Wraps all methods of the given `obj` to trigger a specified callback before executing
-    the original method. This is useful for monitoring or observing object activity, such
-    as logging or tracking method calls.
-
-    This function dynamically intercepts all methods of the input `obj` object and wraps
-    them such that the `callback` function is executed prior to the method's actual
-    invocation. The wrapped methods retain their arguments, return values, and
-    attributes.
-
-    Parameters
-    ----------
-    obj : object
-        The target object whose methods are to be monitored. All methods of this object
-        will be wrapped to include the `callback`.
-    callback : Callable[[], None]
-        A zero-argument callable that is executed before any method of `obj` is invoked.
-
-    Returns
-    -------
-    object
-        The original `obj`, with its methods wrapped to call `callback` before
-        execution.
-
-    Raises
-    ------
-    AttributeError
-        If an attribute of `obj` cannot be fetched or set while wrapping methods.
-
-    Notes
-    -----
-    The `callback` function is expected to handle side-effects or monitoring concerns
-    (e.g., logging, notifications). This function does not guarantee thread safety if
-    the `obj`'s methods are accessed simultaneously from multiple threads.
-
-    See Also
-    --------
-    functools.update_wrapper : Used internally to update the wrapped function's
-        metadata to match the original function.
-
-    Examples
-    --------
-    >>> from functools import partial
-    >>> class MyClass:
-    ...     def method(self, x):
-    ...         print(f'Method called with {x}')
-    >>> obj = MyClass()
-    >>> def my_callback():
-    ...     print('Callback triggered!')
-    >>> monitored_obj = activity_monitor(obj, my_callback)
-    >>> monitored_obj.method(10)
-    Callback triggered!
-    Method called with 10
+    the original method.
     """
     for attr in dir(obj):
-        if inspect.ismethod(getattr(obj, attr)):
-            original_method = getattr(obj, attr)
+        try:
+            got = getattr(obj, attr)
+        except Exception:
+            continue
+        if not inspect.ismethod(got) and not inspect.isfunction(getattr(type(obj), attr, None)):
+            continue
+        original_method = got
 
+        def _make_wrapper(orig):
             def f(*args, **kwargs):
                 callback()
-                original_method(*args, **kwargs)
-            setattr(obj, attr, update_wrapper(f, original_method))
+                return orig(*args, **kwargs)
+            return update_wrapper(f, orig)
+
+        setattr(obj, attr, _make_wrapper(original_method))
     return obj
 
 class PowerManagerMode(StrEnum):
@@ -221,7 +179,7 @@ class PowerManager(QObject):
             self.mode = PowerManagerMode.AUTO
             return
 
-        now = datetime.datetime.now()
+        now = datetime.datetime.now(datetime.timezone.utc) if self._next_warmup_date and self._next_warmup_date.tzinfo else datetime.datetime.now()
         logger.debug(f"{self._next_warmup_date - now} -- {datetime.timedelta(seconds=self.warmup_period + 1.)}")
         if self._next_warmup_date - now < datetime.timedelta(seconds=self.warmup_period + 1.):
             self.mode = PowerManagerMode.SCAN
@@ -277,10 +235,16 @@ class PowerManager(QObject):
         self._lights_power_on()
         self._glights_power_off()
 
+    def prepare_for_scan(self):
+        self._prepare_for_scan()
+
     def _resume_auto(self):
         self._cnc_power_on()
         self._lights_power_off()
         self._glights_power_on()
+
+    def resume_auto(self):
+        self._resume_auto()
 
     def get_cnc(self):
         return self.cnc

--- a/src/controller/plantimager/controller/scanner/powermanager.py
+++ b/src/controller/plantimager/controller/scanner/powermanager.py
@@ -85,6 +85,9 @@ class PowerManager(QObject):
         manual_mode_timer : QTimer
             A single-shot timer used to manage the manual mode timeout. It triggers
             after 5 minutes (converted to milliseconds).
+        warmup_timer : QTimer
+            A single-shot timer that powers up the scanner at ``next_scan - warmup_period``
+            once a scan has been armed via :meth:`arm_for_scan`.
         cnc_connect_timer : QTimer
             A regular timer used to periodically attempt CNC reconnections. It is
             triggered every 1.2 seconds (1200 milliseconds).
@@ -104,6 +107,8 @@ class PowerManager(QObject):
         self.warmup_period: float = warmup_period
         self.manual_mode_timer = QTimer(parent=self, singleShot=True, interval=60 * 5 * 1000)  # 5 minutes in ms
         self.manual_mode_timer.timeout.connect(self._manual_mode_timeout)
+        self.warmup_timer = QTimer(parent=self, singleShot=True)
+        self.warmup_timer.timeout.connect(self._on_warmup_timer)
         self.cnc_connect_timer = QTimer(parent=self, singleShot=False, interval=1200)
         self.cnc_connect_timer.timeout.connect(self._cnc_connect)
         self._mode: PowerManagerMode = PowerManagerMode.AUTO
@@ -253,5 +258,54 @@ class PowerManager(QObject):
         # For future automatic light management
         pass
 
-    def set_next_auto_warmup_date(self, date: datetime.datetime):
-        self._next_warmup_date = date
+    @Slot()
+    def _on_warmup_timer(self):
+        """Warm-up timer fired — power up the scanner for an imminent scan."""
+        self.mode = PowerManagerMode.SCAN
+
+    def arm_for_scan(self, next_scan_at: datetime.datetime, standby_threshold_sec: int):
+        """
+        Decide and schedule power so the scanner is ready for a scan at ``next_scan_at``.
+
+        If the next scan is far enough away (``delta > standby_threshold_sec``) the
+        manager returns to ``AUTO`` (growth lights, scanner idle) and arms its internal
+        warm-up timer to power up ``warmup_period`` before the scan. Otherwise it stays
+        in ``SCAN`` mode (already powered). This is the single power-policy decision;
+        warnings are logged for each branch.
+
+        Called by ``TimeLapse`` each time it re-arms for the next scheduled scan.
+
+        Parameters
+        ----------
+        next_scan_at : datetime.datetime
+            When the next scan will run (timezone-aware).
+        standby_threshold_sec : int
+            If the next scan is sooner than this many seconds, keep the scanner powered
+            on in ``SCAN`` mode instead of dropping to ``AUTO``.
+        """
+        self.warmup_timer.stop()
+        if next_scan_at.tzinfo is None:
+            next_scan_at = next_scan_at.replace(tzinfo=datetime.timezone.utc)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        delta = (next_scan_at - now).total_seconds()
+
+        if delta > standby_threshold_sec:
+            logger.info(
+                f"Next scan in {delta:.0f}s (above standby threshold {standby_threshold_sec}s), "
+                f"dropping to AUTO and warming up before the scan."
+            )
+            self._next_warmup_date = next_scan_at - datetime.timedelta(seconds=self.warmup_period)
+            self.mode = PowerManagerMode.AUTO
+            warmup_in = max(0, delta - self.warmup_period)
+            self.warmup_timer.setInterval(int(warmup_in * 1000))
+            self.warmup_timer.start()
+        else:
+            logger.info(
+                f"Next scan in {delta:.0f}s (within standby threshold {standby_threshold_sec}s), "
+                f"keeping scanner powered in SCAN mode."
+            )
+            self.mode = PowerManagerMode.SCAN
+
+    def set_manual(self):
+        """Enter MANUAL mode, powering up the scanner for manual operation."""
+        self.mode = PowerManagerMode.MANUAL

--- a/src/controller/plantimager/controller/scanner/rpc_controller.py
+++ b/src/controller/plantimager/controller/scanner/rpc_controller.py
@@ -145,6 +145,50 @@ class RPCControllerServer(ControllerDevice, RPCServer):
         """Start a scanning operation with the current configuration."""
         self.scanner.scan()
 
+    @RPCServer.register_method_json(timeout=None)
+    def start_timelapse(self, config):
+        """Create and start a timelapse from a configuration dict.
+
+        Parameters
+        ----------
+        config : dict
+            Timelapse configuration (``timelapse`` sub-dict for mode/schedule,
+            plus ``ScanPath``/``Metadata``/camera settings).
+
+        Returns
+        -------
+        str
+            The unique id of the created timelapse.
+        """
+        return self.scanner.start_timelapse(config)
+
+    @RPCServer.register_method_json()
+    def get_active_timelapse(self):
+        """Return a serialisable snapshot of the active timelapse, or None."""
+        return self.scanner.get_active_timelapse()
+
+    @RPCServer.register_method_json()
+    def cancel_timelapse(self):
+        """Cancel the active timelapse, if any."""
+        self.scanner.cancel_timelapse()
+
+    @RPCServer.register_method_json()
+    def preview_timelapse(self, config):
+        """Return the schedule computed for a config, without starting it.
+
+        Parameters
+        ----------
+        config : dict
+            Timelapse configuration to preview.
+
+        Returns
+        -------
+        dict
+            Computed schedule: ``{"mode": str, "schedule_times": [iso, ...],
+            "n_scans": int}``.
+        """
+        return self.scanner.preview_timelapse(config)
+
     @RPCProperty(notify=ControllerDevice.progressChanged)
     def progress(self):
         """Get the current progress value of the scanner.

--- a/src/controller/plantimager/controller/scanner/scan.py
+++ b/src/controller/plantimager/controller/scanner/scan.py
@@ -1,0 +1,510 @@
+"""
+Define the Scan class which handles the scanning process by using the grbl CNC and DataUploader to
+upload data to PlantDB
+"""
+
+import os
+import subprocess
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor, Future, ALL_COMPLETED, FIRST_COMPLETED
+from concurrent.futures import wait as cf_wait
+from io import BytesIO
+from typing import Literal, Any
+from weakref import finalize
+from datetime import datetime
+
+from PySide6.QtCore import QObject, Signal, Property
+from plantdb.client.plantdb_client import PlantDBClient
+from requests.exceptions import RequestException
+
+from plantimager.commons.logging import create_logger
+from plantimager.controller.camera.PiCameraComm import PiCameraComm
+from plantimager.controller.scanner.dummy_cnc import DummyCNC
+from plantimager.controller.scanner.grbl import CNC
+from plantimager.controller.scanner.hal import DataItem, AbstractCNC
+from plantimager.controller.scanner.path import Path, Circle, CalibrationPath2, CustomPath
+from plantimager.controller.scanner.path import PathElement
+from plantimager.controller.scanner.path import Pose
+
+logger = create_logger(__name__)
+
+DB_UPLOADER_QUEUE_SIZE = int(os.getenv("DB_UPLOADER_QUEUE_SIZE", "10"))
+TZ = time.tzname[0]
+
+class DataUploader():
+    """Worker thread that uploads scan data from a queue to a plantdb instance.
+
+    This class manages asynchronous uploads of image data to a PlantDB database
+    using a thread pool. It limits the number of concurrent uploads and provides
+    a queue mechanism to handle backpressure.
+
+    Attributes
+    ----------
+    db_client : PlantDBClient
+        Client for communicating with the PlantDB database
+    jobs : set[Future]
+        Set of active upload job futures
+    pool : ThreadPoolExecutor
+        Thread pool for executing upload tasks
+    queue_size : int
+        Maximum number of concurrent upload jobs
+
+    Notes
+    -----
+    - Uses ThreadPoolExecutor with 4 worker threads for parallel uploads
+    - Automatically shuts down the thread pool when the object is garbage collected
+    - Blocks new uploads when the queue is full until a slot becomes available
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from plantdb.client.plantdb_client import PlantDBClient
+    >>> from plantimager.controller.scanner.scanner import DataUploader
+    >>> from plantimager.controller.scanner.hal import DataItem
+    >>> client = PlantDBClient("http://localhost:5000")
+    >>> uploader = DataUploader(client, queue_size=10)
+    >>> # Generate random RGB data (values from 0-255)
+    >>> rgb_data = np.random.randint(0, 256, (200, 150, 3), dtype=np.uint8)
+    >>> metadata = {'description': 'Random RGB test image', 'author': 'John Doe'}
+    >>> data_item = DataItem(rgb_data, metadata)
+    >>> uploader.upload("scan_001", "images", data_item)
+    """
+
+    def __init__(self, db_client: PlantDBClient, queue_size: int):
+        """Initialize the DataUploader with a database client and queue size.
+
+        Parameters
+        ----------
+        db_client : plantdb.client.plantdb_client.PlantDBClient
+            Client for communicating with the PlantDB database
+        queue_size : int
+            Maximum number of concurrent upload jobs
+        """
+        self.db_client = db_client
+        self.jobs: set[Future] = set()  # Track active upload jobs
+        self.pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix=__name__)
+        self.queue_size = queue_size
+        # Ensure thread pool is properly shut down when object is garbage collected
+        finalize(self, self.pool.shutdown, wait=True, cancel_futures=True)
+
+    def _upload(self, scan_id: str, fileset: str, data: DataItem):
+        """Internal method to perform the actual upload operation.
+
+        Parameters
+        ----------
+        scan_id : str
+            Identifier of the scan in the database
+        fileset : str
+            Identifier of the fileset within the scan
+        data : DataItem
+            Data item containing the image and metadata to upload
+
+        Notes
+        -----
+        This is a private method called by the public upload method.
+        """
+        # Create a BytesIO buffer from the image data
+        buffer = BytesIO(data.image)
+        buffer.seek(0)  # Reset buffer position to start
+        try:
+            # Upload the file to the database with metadata
+            response = self.db_client.create_file(
+                buffer, file_id=f"{data.metadata['camera_name']}-{data.idx:0>5}", ext=data.image_ext,
+                scan_id=scan_id, fileset_id=fileset, metadata=data.metadata
+            )
+        except Exception as e:
+            # Log any exceptions that occur during upload
+            traceback.print_exception(e)
+        return
+
+    def upload(self, scan_id: str, fileset: str, data: DataItem):
+        """Upload data file to specified fileset of scan_id in a plantdb instance.
+
+        This method queues an upload job to the thread pool. If the queue is full,
+        it blocks until a slot becomes available.
+
+        Parameters
+        ----------
+        scan_id : str
+            Identifier of the scan in the database
+        fileset : str
+            Identifier of the fileset within the scan
+        data : DataItem
+            Data item containing the image and metadata to upload
+
+        Notes
+        -----
+        This method may block indefinitely if the upload queue is full and
+        no upload jobs are completing.
+        """
+        # Wait if number of jobs submitted is greater than queue_size
+        if len(self.jobs) >= self.queue_size:
+            cf_wait(self.jobs, return_when=FIRST_COMPLETED)  # blocking
+
+        # Submit the upload job to the thread pool
+        future_: Future = self.pool.submit(self._upload, scan_id, fileset, data)
+        self.jobs.add(future_)  # Track the job
+        future_.add_done_callback(self.jobs.remove)  # Remove job when done
+
+
+class Scan(QObject):
+    """
+    Represents a scanner for executing complex scanning operations, including positioning,
+    capturing data from multiple cameras, and uploading results to a remote database.
+
+    This class integrates hardware (such as CNC controllers and cameras) and software
+    components to automate the scanning and data gathering workflow. It also provides
+    progress tracking and metadata management, making it suitable for dynamic and complex
+    scanning needs.
+
+    Attributes
+    ----------
+    progressChanged : Signal(int)
+        Signal emitted when the scan progress changes.
+    maxProgressChanged : Signal(int)
+        Signal emitted when the maximum progress value changes.
+    cnc : AbstractCNC
+        The CNC controller for managing scanner movements.
+    db_url : str
+        URL of the database to upload scan data.
+    db_client : PlantDBClient
+        Client used for database operations.
+    uploader : DataUploader
+        Uploads data items to the database.
+    cameras : list of PiCameraComm
+        List of camera objects used for capturing images.
+    path : Path
+        Path object representing the set of positions for the scan.
+    scan_id : str
+        Unique identifier for the scan.
+    fileset : str
+        Name of the fileset for storing images.
+    _progress : int
+        Tracks the current scan progress.
+    _max_progress : int
+        Maximum possible progress value, derived from the length of the scan path.
+    config : dict
+        Configuration for the scan, including metadata and hardware settings.
+    dataset_metadata : Any
+        Metadata related to the biological or scanned object.
+    hw_metadata : Any
+        Metadata related to the hardware used.
+    _start_time : int or None
+        Start time of the scan in UNIX timestamp format, or None if not started.
+    _stop_time : int or None
+        Stop time of the scan in UNIX timestamp format, or None if not completed.
+
+    Notes
+    -----
+    - This class is designed for integration with QML and emits progress signals.
+    - Attributes such as `_progress` and `_max_progress` track scanning operations.
+    - The scanning process is highly configurable using `config` — ensure it contains
+      the necessary fields such as metadata and hardware details.
+    """
+    progressChanged = Signal(int)
+    maxProgressChanged = Signal(int)
+
+    def __init__(self, cnc: AbstractCNC, db_url: str, cameras: list[PiCameraComm], path: Path, scan_id: str,
+                 config: dict[str, Any], parent=None):
+        super().__init__(parent)
+        self.cnc = cnc
+        self.db_url = db_url
+        self.db_client = PlantDBClient(db_url)
+        self.uploader = DataUploader(self.db_client, queue_size=DB_UPLOADER_QUEUE_SIZE)
+        self.cameras = cameras
+        self.path = path
+        self.scan_id = scan_id
+        self.fileset = "images"
+        self._progress = 0
+        self._max_progress = len(path)
+        self.config = config
+        # Store metadata for the scan
+        self.dataset_metadata = config["Metadata"]["object"]  # Biological metadata
+        self.hw_metadata = config["Metadata"]["hardware"]  # Hardware metadata
+
+        # time
+        self._start_time: int | None = None
+        self._stop_time: int | None = None
+
+    @Property(int, notify=progressChanged)
+    def progress(self) -> int:
+        """Get the current scan progress.
+
+        Returns
+        -------
+        int
+            Current progress value
+
+        Notes
+        -----
+        This property is exposed to QML and notifies via progressChanged signal.
+        """
+        return self._progress
+
+    @Property(int, notify=maxProgressChanged)
+    def max_progress(self) -> int:
+        """Get the maximum scan progress value.
+
+        Returns
+        -------
+        int
+            Maximum progress value
+
+        Notes
+        -----
+        This property is exposed to QML and notifies via maxProgressChanged signal.
+        """
+        return self._max_progress
+
+    def get_position(self) -> Pose:
+        """Get the current position of the scanner.
+
+        Returns
+        -------
+        Pose
+            Current position as a 5D pose (x, y, z, pan, tilt)
+
+        Notes
+        -----
+        The Z and tilt values are always set to 0 as the scanner only
+        supports 3D movement (X, Y, and pan rotation).
+        """
+        # Get raw position from CNC controller
+        x, y, z = self.cnc.get_position()
+        # Convert to Pose object (z is pan, tilt is always 0)
+        pose = Pose(x, y, 0, pan=z, tilt=0)
+        return pose
+
+    def get_target_pose(self, x: PathElement) -> Pose:
+        """Calculate the target pose from a path element.
+
+        This method creates a target pose by combining the current position
+        with the specified values from the path element. For any attribute
+        not specified in the path element, the current position value is used.
+
+        Parameters
+        ----------
+        x : PathElement
+            Path element containing the desired position attributes
+
+        Returns
+        -------
+        Pose
+            The calculated target pose
+
+        Notes
+        -----
+        If a coordinate in the path element is None, the current position
+        value for that coordinate is used instead.
+        """
+        # Get current position
+        pos = self.get_position()
+        # Create new pose
+        target_pose = Pose()
+
+        # For each attribute (x, y, z, pan, tilt)
+        for attr in pos.attributes():
+            if getattr(x, attr) is None:
+                # If path element doesn't specify this attribute, use current position
+                setattr(target_pose, attr, getattr(pos, attr))
+            else:
+                # Otherwise use the value from the path element
+                setattr(target_pose, attr, getattr(x, attr))
+
+        return target_pose
+
+    def set_position(self, pose: Pose) -> None:
+        """Set the position of the scanner from a 5D Pose.
+
+        Parameters
+        ----------
+        pose : Pose
+            Target position as a 5D pose (x, y, z, pan, tilt)
+
+        Notes
+        -----
+        Only X, Y, and pan values are used; Z and tilt are ignored.
+
+        Examples
+        --------
+        >>> pose = Pose(100, 100, 0, pan=45, tilt=0)
+        >>> scan.set_position(pose)
+        """
+        logger.info(f"Moving arm to {pose}")
+        # Move CNC to the specified position (only x, y, and pan are used)
+        self.cnc.moveto(pose.x, pose.y, pose.pan)
+        time.sleep(0.1)  # Wait for movement to complete as grbl returns a bit early
+
+    def grab(self, idx: int, metadata: dict, camera: PiCameraComm) -> DataItem:
+        """Capture an image from a camera and upload it to the database.
+
+        This method captures an image from the specified camera, adds metadata,
+        creates a DataItem, and uploads it to the database.
+
+        Parameters
+        ----------
+        idx : int
+            Identifier for the data item to create
+        metadata : dict
+            Dictionary of metadata to associate with the image
+        camera : PiCameraComm
+            Camera object to use for capturing the image
+
+        Returns
+        -------
+        DataItem
+            The created data item containing the image and metadata
+
+        Notes
+        -----
+        The method performs these steps:
+        1. Capture image from camera
+        2. Update metadata with image information
+        3. Create a DataItem
+        4. Upload the data to the database
+
+        Examples
+        --------
+        >>> metadata = {"camera_name": "cam1", "approximate_pose": [100, 100, 0, 45, 0]}
+        >>> data_item = scan.grab(1, metadata, camera)
+        """
+        # Capture image from camera
+        image_future = camera.getImage(lores=False)
+        buffer, buffer_info = image_future.result()  # Wait for image capture to complete
+
+        # Update metadata with image information from camera
+        metadata.update(buffer_info)
+
+        # Create data item with image and metadata
+        data = DataItem(idx, buffer, image_ext=buffer_info["format"], metadata=metadata)
+
+        # Upload data to database
+        self.uploader.upload(scan_id=self.scan_id, fileset=self.fileset, data=data)
+
+        return data
+
+    def scan(self) -> None:
+        """Execute the complete scanning process.
+
+        This method performs a full scan by:
+        1. Validating that all required components are available
+        2. Creating the scan and fileset in the database
+        3. Following the scan path and capturing images at each position
+        4. Uploading all captured images with metadata
+
+        Raises
+        ------
+        RuntimeError
+            If any required component is missing
+
+        Notes
+        -----
+        - Validates all prerequisites before starting
+        - Creates scan and fileset in the database
+        - Follows the scan path, moving the CNC to each position
+        - Captures images from all cameras at each position
+        - Uploads images with position and camera metadata
+        - Uses a thread pool for parallel image capture
+        - Updates progress throughout the scan
+
+        """
+        # Validate all required components are available
+        if not self.config: raise RuntimeError("Config not set for scan")
+        if not self.path: raise RuntimeError("Path not set for scan")
+        if not self.db_url: raise RuntimeError("DB url not set for scan")
+        if not self.db_client: raise RuntimeError("DB client not set for scan")
+        if not self.uploader: raise RuntimeError("Uploader not set for scan")
+        if not self.scan_id: raise RuntimeError("Scan id not set for scan")
+        if not self.cameras: raise RuntimeError("No Cameras connected")
+
+        # Update metadata if using dummy CNC
+        if isinstance(self.cnc, DummyCNC):
+            self.hw_metadata["name"] = "DummyCNC"
+
+        self._start_time = time.time()
+        time_info = {
+            "timezone": TZ,
+            "start_time": datetime.fromtimestamp(self._start_time).astimezone().isoformat(timespec="seconds"),
+            "stop_time": None
+        }
+        self.config.update(time_info)
+
+        # Create the scan on the remote database
+        try:
+            # Combine dataset and hardware metadata
+            self.db_client.create_scan(self.scan_id, metadata=self.config)
+        except RequestException as e:
+            logger.error(f"{e}")
+        except ValueError as e:
+            logger.error(f"{e}")
+            logger.error(f"Scan {self.scan_id} already exists in plantdb")
+
+        # Create the image fileset on the remote database
+        try:
+            self.db_client.create_fileset(self.fileset, self.scan_id)
+        except RequestException as e:
+            logger.error(f"{e}")
+        except ValueError as e:
+            logger.error(f"{e}")
+            logger.error(f"Fileset {self.fileset} already exists for scan {self.scan_id}")
+
+        # Execute the scan using a thread pool for parallel image capture
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            shot_id = 0  # Initialize shot counter
+            self._progress = 0  # Reset progress
+
+            # Follow each point in the scan path
+            for x in self.path:
+                # Update progress
+                self._progress += 1
+                self.progressChanged.emit(self._progress)
+
+                # Calculate and move to the target position
+                pose = self.get_target_pose(x)
+                self.set_position(pose)
+
+                # Get actual arm position after movement
+                arm_pose = self.get_position()
+                jobs = []  # List to track image capture jobs
+
+                # Capture images from each camera
+                for camera in self.cameras:
+                    name: str = camera.name
+                    # Skip cameras not in config
+                    if name not in self.config:
+                        logger.debug(f"Camera {name} not in config, skipping")
+                        continue
+
+                    # Get camera parameters and calculate camera position
+                    camera_param = self.config[name]
+                    camera_offset = Pose(**camera_param["offset"])
+                    camera_pose = arm_pose + camera_offset  # Apply offset to arm position
+
+                    # Prepare metadata for this shot
+                    metadata = {
+                        **camera_param,  # Include all camera parameters
+                        "camera_name": name,
+                        "approximate_pose": [camera_pose.x, camera_pose.y, camera_pose.z, camera_pose.pan,
+                                             camera_pose.tilt],  # Camera position
+                        "shot_id": shot_id,  # Unique ID for this shot
+                    }
+
+                    # Submit image capture job to thread pool
+                    jobs.append(executor.submit(self.grab, shot_id, metadata, camera))
+
+                shot_id += 1
+                # Wait for all image captures to complete before moving to next position
+                cf_wait(jobs, return_when=ALL_COMPLETED)
+
+        # Move the arm back close to origin
+        #self.cnc.moveto(10, 10,-10)
+        time.sleep(1)
+        #self.cnc.home()
+        self.cnc.moveto(20, 20, 45)
+
+        self._stop_time = time.time()
+        self.db_client.update_scan_metadata(self.scan_id, {
+            "stop_time": datetime.fromtimestamp(self._stop_time).astimezone().isoformat(timespec="seconds"),
+        })
+        logger.info(f"Scan completed")  # Log completion

--- a/src/controller/plantimager/controller/scanner/scan.py
+++ b/src/controller/plantimager/controller/scanner/scan.py
@@ -205,12 +205,11 @@ class Scan(QObject):
     progressChanged = Signal(int)
     maxProgressChanged = Signal(int)
 
-    def __init__(self, cnc: AbstractCNC, db_url: str, cameras: list[PiCameraComm], path: Path, scan_id: str,
+    def __init__(self, cnc: AbstractCNC, db_client: PlantDBClient, cameras: list[PiCameraComm], path: Path, scan_id: str,
                  config: dict[str, Any], parent=None):
         super().__init__(parent)
         self.cnc = cnc
-        self.db_url = db_url
-        self.db_client = PlantDBClient(db_url)
+        self.db_client = db_client
         self.uploader = DataUploader(self.db_client, queue_size=DB_UPLOADER_QUEUE_SIZE)
         self.cameras = cameras
         self.path = path
@@ -412,7 +411,6 @@ class Scan(QObject):
         # Validate all required components are available
         if not self.config: raise RuntimeError("Config not set for scan")
         if not self.path: raise RuntimeError("Path not set for scan")
-        if not self.db_url: raise RuntimeError("DB url not set for scan")
         if not self.db_client: raise RuntimeError("DB client not set for scan")
         if not self.uploader: raise RuntimeError("Uploader not set for scan")
         if not self.scan_id: raise RuntimeError("Scan id not set for scan")

--- a/src/controller/plantimager/controller/scanner/scanner.py
+++ b/src/controller/plantimager/controller/scanner/scanner.py
@@ -3,18 +3,24 @@
 
 """Scanner Module for Plant Imaging Systems.
 
-A comprehensive module for controlling 3D plant imaging systems, managing the scanning process,
-camera control, and data acquisition. This module coordinates the movement of CNC hardware,
-image capture from multiple cameras, and data upload to a database.
+``Scanner`` is the UI/RPC bridge for the plant imaging system. It owns the
+device state (CNC, cameras, database connection) and the single shared
+``PowerManager``, and delegates the actual work to the specialised classes:
+
+* :class:`Scan`  — one 3D capture pass (path traversal, capture, upload).
+* :class:`TimeLapse` — scheduling a *series* of scans over time (``interval``,
+  ``fixed_times`` or a single pass). ``Scanner.timelapse`` is the active job.
+* :class:`PowerManager` — GPIO power and warm-up/power-on decisions.
+
+``Scanner`` itself does **not** run the scan loop anymore; it forwards signals
+and methods to/from the active ``Scan``/``TimeLapse`` so that QML and the RPC
+server keep a stable, bridge-only interface.
 
 Key Features:
-- Automated scanning along predefined paths with precise positioning
-- Multi-camera support with synchronized image capture
-- Asynchronous data upload to a PlantDB database
-- Progress tracking and reporting
-- QML integration for GUI applications
+- Bridge for QML integration (properties/signals) and the RPC controller
+- Owns one shared :class:`PowerManager` and the active :class:`TimeLapse`
+- ``run_scan`` delegates to a single :class:`Scan` (custom dataset id)
 - Fallback to dummy hardware when physical hardware is unavailable
-- Comprehensive metadata collection for each captured image
 
 Usage Examples:
 ```python
@@ -23,21 +29,15 @@ Usage Examples:
 >>> scanner.set_db_url("http://localhost:5000")
 >>> scanner.configure_scan(config_dict)  # Configure scan parameters
 >>> scanner.set_scan_id("plant_scan_001")  # Set scan identifier
->>> scanner.scan()  # Start the scanning process
+>>> scanner.run_scan()  # Start a single scanning operation
 ```
 """
 
 import importlib
 import time
-import traceback
-from concurrent.futures import ALL_COMPLETED
-from concurrent.futures import FIRST_COMPLETED
-from concurrent.futures import Future
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import wait
-from io import BytesIO
+import datetime
+from datetime import timezone
 from typing import Literal
-from weakref import finalize
 
 import numpy as np
 from PySide6.QtCore import Property
@@ -48,19 +48,21 @@ from PySide6.QtCore import Slot
 from PySide6.QtQml import QmlElement
 from PySide6.QtQml import QmlUncreatable
 from plantdb.client.plantdb_client import PlantDBClient
-from requests.exceptions import RequestException
 
 from plantimager.commons.logging import create_logger
 from plantimager.controller.camera.PiCameraComm import PiCameraComm
 from plantimager.controller.scanner.dummy_cnc import DummyCNC
 from plantimager.controller.scanner.grbl import CNC
-from plantimager.controller.scanner.hal import DataItem
 from plantimager.controller.scanner.path import CalibrationPath2
 from plantimager.controller.scanner.path import Circle
 from plantimager.controller.scanner.path import CustomPath
 from plantimager.controller.scanner.path import Path
-from plantimager.controller.scanner.path import PathElement
 from plantimager.controller.scanner.path import Pose
+from plantimager.controller.scanner.powermanager import PowerManager
+from plantimager.controller.scanner.scan import Scan
+from plantimager.controller.scanner.timelapse import TimeLapse
+from plantimager.controller.scanner.timelapse import TimeLapseState
+from plantimager.controller.scanner.timelapse_store import TimelapseStore
 
 QML_IMPORT_NAME = "PlantImagerApp.Scanner"
 QML_IMPORT_MAJOR_VERSION = 1
@@ -68,178 +70,59 @@ QML_IMPORT_MAJOR_VERSION = 1
 logger = create_logger(__name__)
 
 
-class DataUploader():
-    """Worker thread that uploads scan data from a queue to a plantdb instance.
-
-    This class manages asynchronous uploads of image data to a PlantDB database
-    using a thread pool. It limits the number of concurrent uploads and provides
-    a queue mechanism to handle backpressure.
-
-    Attributes
-    ----------
-    db_client : PlantDBClient
-        Client for communicating with the PlantDB database
-    jobs : set[Future]
-        Set of active upload job futures
-    pool : ThreadPoolExecutor
-        Thread pool for executing upload tasks
-    queue_size : int
-        Maximum number of concurrent upload jobs
-
-    Notes
-    -----
-    - Uses ThreadPoolExecutor with 4 worker threads for parallel uploads
-    - Automatically shuts down the thread pool when the object is garbage collected
-    - Blocks new uploads when the queue is full until a slot becomes available
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from plantdb.client.plantdb_client import PlantDBClient
-    >>> from plantimager.controller.scanner.scanner import DataUploader
-    >>> from plantimager.controller.scanner.hal import DataItem
-    >>> client = PlantDBClient("http://localhost:5000")
-    >>> uploader = DataUploader(client, queue_size=10)
-    >>> # Generate random RGB data (values from 0-255)
-    >>> rgb_data = np.random.randint(0, 256, (200, 150, 3), dtype=np.uint8)
-    >>> metadata = {'description': 'Random RGB test image', 'author': 'John Doe'}
-    >>> data_item = DataItem(rgb_data, metadata)
-    >>> uploader.upload("scan_001", "images", data_item)
-    """
-
-    def __init__(self, db_client: PlantDBClient, queue_size: int):
-        """Initialize the DataUploader with a database client and queue size.
-
-        Parameters
-        ----------
-        db_client : plantdb.client.plantdb_client.PlantDBClient
-            Client for communicating with the PlantDB database
-        queue_size : int
-            Maximum number of concurrent upload jobs
-        """
-        self.db_client = db_client
-        self.jobs: set[Future] = set()  # Track active upload jobs
-        self.pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix=__name__)
-        self.queue_size = queue_size
-        # Ensure thread pool is properly shut down when object is garbage collected
-        finalize(self, self.pool.shutdown, wait=True, cancel_futures=True)
-
-    def _upload(self, scan_id: str, fileset: str, data: DataItem):
-        """Internal method to perform the actual upload operation.
-
-        Parameters
-        ----------
-        scan_id : str
-            Identifier of the scan in the database
-        fileset : str
-            Identifier of the fileset within the scan
-        data : DataItem
-            Data item containing the image and metadata to upload
-
-        Notes
-        -----
-        This is a private method called by the public upload method.
-        """
-        # Create a BytesIO buffer from the image data
-        buffer = BytesIO(data.image)
-        buffer.seek(0)  # Reset buffer position to start
-        try:
-            # Upload the file to the database with metadata
-            response = self.db_client.create_file(
-                buffer, file_id=f"{data.metadata['camera_name']}-{data.idx:0>5}", ext=data.image_ext,
-                scan_id=scan_id, fileset_id=fileset, metadata=data.metadata
-            )
-        except Exception as e:
-            # Log any exceptions that occur during upload
-            traceback.print_exception(e)
-        return
-
-    def upload(self, scan_id: str, fileset: str, data: DataItem):
-        """Upload data file to specified fileset of scan_id in a plantdb instance.
-
-        This method queues an upload job to the thread pool. If the queue is full,
-        it blocks until a slot becomes available.
-
-        Parameters
-        ----------
-        scan_id : str
-            Identifier of the scan in the database
-        fileset : str
-            Identifier of the fileset within the scan
-        data : DataItem
-            Data item containing the image and metadata to upload
-
-        Notes
-        -----
-        This method may block indefinitely if the upload queue is full and
-        no upload jobs are completing.
-        """
-        # Wait if the number of jobs submitted is greater than queue_size
-        if len(self.jobs) >= self.queue_size:
-            wait(self.jobs, return_when=FIRST_COMPLETED)  # blocking
-
-        # Submit the upload job to the thread pool
-        future_: Future = self.pool.submit(self._upload, scan_id, fileset, data)
-        self.jobs.add(future_)  # Track the job
-        future_.add_done_callback(self.jobs.remove)  # Remove job when done
-
-
 @QmlElement
 @QmlUncreatable("Scanner cannot be created from QML")
 class Scanner(QObject):
-    """Main controller for the plant imaging scanner system.
+    """Main controller bridge for the plant imaging scanner system.
 
-    This class coordinates the scanning process, including CNC movement control,
-    camera management, image capture, and data upload. It integrates with QML
-    for GUI applications and provides signals for progress tracking.
+    This class owns the device state and delegates actual scanning work to
+    :class:`Scan` / :class:`TimeLapse` / :class:`PowerManager`. It exposes the
+    QML/RPC surface: camera management, CNC state, progress, path info and the
+    active timelapse.
 
     Attributes
     ----------
     progressChanged : Signal(int)
-        Signal emitted when scan progress changes
+        Signal emitted when the per-position scan progress changes.
     maxProgressChanged : Signal(int)
-        Signal emitted when maximum progress value changes
+        Signal emitted when maximum per-position progress changes.
     readyToScanChanged : Signal(bool)
-        Signal emitted when scanner ready state changes
+        Signal emitted when scanner ready state changes.
     cameraNamesChanged : Signal(list)
-        Signal emitted when the list of camera names changes
+        Signal emitted when the list of camera names changes.
+    timelapseChanged : Signal(QObject)
+        Signal emitted when the active timelapse object is set.
+    timelapseProgressChanged : Signal(int, int)
+        Schedule-level progress (current scan index, total scans).
+    timelapseStateChanged : Signal(str)
+        Signal emitted when the timelapse state changes.
+    timelapseErrorOccurred : Signal(str)
+        Signal emitted when a timelapse scan fails.
+    timelapseFinished : Signal()
+        Signal emitted when the active timelapse reaches a terminal state.
+
     config : dict
-        Configuration dictionary for the scan
+        Configuration dictionary for the scan.
     cnc : CNC or DummyCNC
-        CNC controller for hardware movement
+        CNC controller for hardware movement.
     cameras : list[PiCameraComm]
-        List of connected cameras
+        List of connected cameras.
     db_url : str or None
-        URL of the PlantDB database
+        URL of the PlantDB database.
     scan_path : Path or None
-        Path to follow during scanning
+        Path to follow during scanning.
     db_client : PlantDBClient or None
-        Client for communicating with the PlantDB database
-    uploader : DataUploader or None
-        Data uploader for sending images to the database
+        Client for communicating with the PlantDB database.
     fileset : str
-        Name of the fileset to store images in
+        Name of the fileset to store images in.
     scan_id : str
-        Identifier for the current scan
-
-    Notes
-    -----
-    - Automatically falls back to DummyCNC if hardware connection fails
-    - Requires configuration, database connection, and at least one camera to scan
-    - Integrates with QML through signals and properties
-
-    Examples
-    --------
-    >>> from plantimager.controller.scanner.scanner import Scanner
-    >>> from plantimager.controller.camera.camera import PiCameraComm
-    >>> camera = PiCameraComm()
-    >>> scanner = Scanner()
-    >>> scanner.set_db_url("http://localhost:5000")
-    >>> scanner.add_camera(camera)
-    >>> scanner.configure_scan(config_dict)
-    >>> scanner.set_scan_id("plant_scan_001")
-    >>> scanner.scan()
+        Identifier for the current scan.
+    power_manager : PowerManager
+        The single shared power manager.
+    timelapse : TimeLapse or None
+        The active timelapse job, or None when idle.
     """
+
     progressChanged = Signal(int)
     maxProgressChanged = Signal(int)
     readyToScanChanged = Signal(bool)
@@ -248,6 +131,13 @@ class Scanner(QObject):
     scanInProgressChanged = Signal(bool)
     scannerWorkingChanged = Signal(bool)
     pathInfoChanged = Signal(str)
+    # --- timelapse / power bridge signals ---
+    timelapseChanged = Signal(QObject)
+    timelapseProgressChanged = Signal(int, int)
+    timelapseStateChanged = Signal(str)
+    timelapseErrorOccurred = Signal(str)
+    timelapseFinished = Signal()
+    powerModeChanged = Signal(str)
 
     def __init__(self):
         """Initialize the Scanner with default settings.
@@ -255,7 +145,8 @@ class Scanner(QObject):
         Notes
         -----
         Attempts to connect to a CNC controller and falls back to a dummy
-        controller if the connection fails.
+        controller if the connection fails. A single shared :class:`PowerManager`
+        is created for GPIO power and warm-up handling.
         """
         super().__init__()
         self.config = {}  # Configuration dictionary
@@ -274,13 +165,12 @@ class Scanner(QObject):
         self.db_url = None  # Database URL
         self.scan_path: Path | None = None  # Path to follow during scanning
 
-        # Progress tracking
+        # Per-position progress of the currently running Scan
         self._progress = 0  # Current progress
         self._max_progress = 0  # Maximum progress value
 
-        # Database and upload components
+        # Database components
         self.db_client: PlantDBClient | None = None  # Database client
-        self.uploader: DataUploader | None = None  # Data uploader
         self.fileset = "images"  # Default fileset name
         self._api_token = ""
 
@@ -289,6 +179,17 @@ class Scanner(QObject):
         self._cnc_connection_timer.timeout.connect(self._try_connect_cnc)
         if isinstance(self.cnc, DummyCNC): self._cnc_connection_timer.start()
 
+        # Timelapse / power management
+        self.timelapse: TimeLapse | None = None
+        self._watched_scan: Scan | None = None
+        self.power_manager = PowerManager(warmup_period=30.0, parent=self)
+        self.power_manager.modeChanged.connect(self.powerModeChanged)
+        self.power_manager.cnc_ready.connect(self._on_power_cnc_ready)
+        self._resume_timelapse()
+
+    # ------------------------------------------------------------------
+    # CNC connection
+    # ------------------------------------------------------------------
     @Slot()
     def _try_connect_cnc(self):
         if isinstance(self.cnc, DummyCNC):
@@ -307,16 +208,29 @@ class Scanner(QObject):
         """Get the type of the CNC controller."""
         return "DummyCNC" if isinstance(self.cnc, DummyCNC) else "GRBL CNC"
 
+    @Slot(object)
+    def _on_power_cnc_ready(self, cnc):
+        """PowerManager connected a real CNC; keep a reference if we only had dummy."""
+        if isinstance(self.cnc, DummyCNC):
+            self.cnc = cnc
+            self.cncTypeChanged.emit(self.cnc_type)
+
+    # ------------------------------------------------------------------
+    # Working / ready state
+    # ------------------------------------------------------------------
     @Property(bool, notify=scanInProgressChanged)
     def scan_in_progress(self) -> bool:
-        """Check if the scanner is currently scanning."""
+        """Check if a single scan (``run_scan``) is currently running."""
         return self._scan_in_progress
 
     @Property(bool, notify=scannerWorkingChanged)
     def scanner_working(self) -> bool:
-        """Check if the scanner is currently working."""
+        """Check if the scanner is currently working (scan or manual movement)."""
         return self._scanner_working or self._scan_in_progress
 
+    # ------------------------------------------------------------------
+    # Camera management
+    # ------------------------------------------------------------------
     @Slot(QObject)
     def add_camera(self, camera: PiCameraComm):
         """Add a camera to the scanner.
@@ -324,7 +238,7 @@ class Scanner(QObject):
         Parameters
         ----------
         camera : PiCameraComm
-            Camera communication object to add
+            Camera communication object to add.
 
         Notes
         -----
@@ -344,7 +258,7 @@ class Scanner(QObject):
         Parameters
         ----------
         camera : PiCameraComm
-            Camera communication object to remove
+            Camera communication object to remove.
 
         Notes
         -----
@@ -353,7 +267,7 @@ class Scanner(QObject):
         Raises
         ------
         ValueError
-            If the camera is not in the list of cameras
+            If the camera is not in the list of cameras.
         """
         self.cameras.remove(camera)  # Remove camera from list
         self.cameraNamesChanged.emit(self.camera_names)  # Update camera names
@@ -361,19 +275,12 @@ class Scanner(QObject):
 
     @Property(list, notify=cameraNamesChanged)
     def camera_names(self) -> list[str]:
-        """Get the list of camera names.
-
-        Returns
-        -------
-        list[str]
-            List of names of connected cameras
-
-        Notes
-        -----
-        This property is exposed to QML and notifies via cameraNamesChanged signal.
-        """
+        """Get the list of camera names."""
         return [cam.name for cam in self.cameras]  # Extract names from camera objects
 
+    # ------------------------------------------------------------------
+    # Database configuration
+    # ------------------------------------------------------------------
     @Slot(str)
     def set_db_url(self, url: str):
         """Set the URL of the database to connect to.
@@ -381,16 +288,11 @@ class Scanner(QObject):
         Parameters
         ----------
         url : str
-            URL of the PlantDB database
+            URL of the PlantDB database.
 
         Notes
         -----
-        Creates a new PlantDBClient and DataUploader if the URL changes.
-        Emits readyToScanChanged signal if the URL changes.
-
-        Examples
-        --------
-        >>> scanner.set_db_url("http://localhost:5000")
+        Creates a new PlantDBClient and emits readyToScanChanged on change.
         """
         if self.db_url != url:  # Only update if URL has changed
             self.db_url = url  # Set new URL
@@ -399,39 +301,19 @@ class Scanner(QObject):
                 self.db_client = PlantDBClient(self.db_url, api_token=self._api_token)  # Create new client
             else:
                 self.db_client = PlantDBClient(self.db_url)
-            self.uploader = DataUploader(self.db_client, 10)  # Create new uploader
             self.readyToScanChanged.emit(self.ready_to_scan)  # Update ready state
 
-    @Property(int, notify=progressChanged)
-    def progress(self) -> int:
-        """Get the current scan progress.
+    def set_api_token(self, token: str):
+        """Set the API token and re-create the PlantDBClient to access the plantdb server."""
+        self._api_token = token
+        if self.db_client:
+            logger.debug("Initializing PlantDBClient with API token...")
+            self.db_client = PlantDBClient(self.db_client.base_url, api_token=self._api_token)
+            logger.debug("Done.")
 
-        Returns
-        -------
-        int
-            Current progress value
-
-        Notes
-        -----
-        This property is exposed to QML and notifies via progressChanged signal.
-        """
-        return self._progress
-
-    @Property(int, notify=maxProgressChanged)
-    def max_progress(self) -> int:
-        """Get the maximum scan progress value.
-
-        Returns
-        -------
-        int
-            Maximum progress value
-
-        Notes
-        -----
-        This property is exposed to QML and notifies via maxProgressChanged signal.
-        """
-        return self._max_progress
-
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
     def configure_scan(self, config: dict):
         """Configure the scan from a configuration dictionary.
 
@@ -445,38 +327,11 @@ class Scanner(QObject):
         config : dict
             Configuration dictionary with the following structure:
             {
-                "ScanPath": {
-                    "class_name": str,  # Name of the path class
-                    "kwargs": dict  # Arguments for path constructor
-                },
-                "Metadata": {
-                    "object": dict,  # Biological metadata
-                    "hardware": dict  # Hardware metadata
-                },
+                "ScanPath": {"class_name": str, "kwargs": dict},
+                "Metadata": {"object": dict, "hardware": dict},
                 # Camera configurations (camera name as key)
-                "camera_name": {
-                    "offset": dict,  # Camera position offset
-                    # Other camera parameters
-                }
+                "camera_name": {"offset": dict, ...}
             }
-
-        Notes
-        -----
-        - Dynamically imports and instantiates the path class
-        - Updates the maximum progress based on path length
-        - Emits maxProgressChanged signal
-
-        Examples
-        --------
-        >>> config = {
-        ...     "ScanPath": {"class_name": "CirclePath", "kwargs": {"radius": 100}},
-        ...     "Metadata": {
-        ...         "object": {"species": "Arabidopsis thaliana"},
-        ...         "hardware": {"scanner_version": "1.0"}
-        ...     },
-        ...     "camera1": {"offset": {"x": 0, "y": 0, "z": 0}}
-        ... }
-        >>> scanner.configure_scan(config)
         """
         self.config = config  # Store the configuration
 
@@ -490,10 +345,6 @@ class Scanner(QObject):
         self._max_progress = len(self.scan_path)
         self.maxProgressChanged.emit(self._max_progress)
 
-        # Store metadata for the scan
-        self.dataset_metadata = config["Metadata"]["object"]  # Biological metadata
-        self.hw_metadata = config["Metadata"]["hardware"]  # Hardware metadata
-
         # Configure cameras
         self._configure_cameras(self.cameras)
 
@@ -506,72 +357,254 @@ class Scanner(QObject):
                 camera.encoding = self.config[camera.name]["encoding"]
                 camera.config = self.config[camera.name]["config"]
 
+    def set_scan_id(self, scan_id: str):
+        """Set the identifier for the scan dataset.
+
+        Parameters
+        ----------
+        scan_id : str
+            Unique identifier for the scan in the database.
+        """
+        self.scan_id = scan_id  # Store the scan ID
+
     @Property(bool, notify=readyToScanChanged)
     def ready_to_scan(self) -> bool:
         """Check if the scanner is ready to perform a scan.
 
-        Returns
-        -------
-        bool
-            True if all required components are set up, False otherwise
-
-        Notes
-        -----
-        This property is exposed to QML and notifies via readyToScanChanged signal.
-
-        The scanner is ready when all of the following are available:
-        - CNC controller
-        - Scan path
-        - At least one camera
-        - Database uploader
-        - Database client
-        - Scan ID
-        - Fileset name
+        The scanner is ready when the required components are available and no
+        scan is in progress.
         """
-        # Check if all required components are available
         if (self.cnc and self.scan_path and self.cameras and
-                self.uploader and self.db_client and
+                self.db_client and
                 hasattr(self, 'scan_id') and self.scan_id and self.fileset and
                 not self._scan_in_progress and not self._scanner_working
         ):
             return True
         return False
 
+    # ------------------------------------------------------------------
+    # Per-position progress (bridged to the active Scan)
+    # ------------------------------------------------------------------
+    @Property(int, notify=progressChanged)
+    def progress(self) -> int:
+        """Get the current per-position scan progress."""
+        return self._progress
+
+    @Property(int, notify=maxProgressChanged)
+    def max_progress(self) -> int:
+        """Get the maximum per-position scan progress value."""
+        return self._max_progress
+
+    def _bridge_scan_signals(self, scan: Scan):
+        """Forward a running Scan's per-position progress to the Scanner surface."""
+        prev = self._watched_scan
+        if prev is not None and prev is not scan:
+            try:
+                prev.progressChanged.disconnect(self.progressChanged)
+                prev.maxProgressChanged.disconnect(self.maxProgressChanged)
+            except (RuntimeError, TypeError):
+                pass
+        self._watched_scan = scan
+        scan.progressChanged.connect(self.progressChanged)
+        scan.maxProgressChanged.connect(self.maxProgressChanged)
+
+    # ------------------------------------------------------------------
+    # Single-scan execution (bridge for the legacy `run_scan` RPC)
+    # ------------------------------------------------------------------
+    def run_scan(self) -> None:
+        """Execute a single scanning operation by delegating to a :class:`Scan`.
+
+        This preserves the legacy single-scan semantics: a custom dataset id
+        (via :meth:`set_scan_id`) and a synchronous, blocking run whose
+        per-position progress is exposed through ``progress``/``max_progress``.
+
+        Raises
+        ------
+        RuntimeError
+            If any required component is missing.
+        """
+        self.scan()
+
+    def scan(self) -> None:
+        """Delegate a single scan to :class:`Scan` (thin bridge).
+
+        Validates prerequisites, builds a :class:`Scan` with the current
+        configuration and dataset id, bridges its per-position progress and
+        runs it synchronously on the calling thread.
+
+        Raises
+        ------
+        RuntimeError
+            If any required component is missing.
+        """
+        if not self.config: raise RuntimeError("Config not set for scan")
+        if not self.scan_path: raise RuntimeError("Path not set for scan")
+        if not self.db_client: raise RuntimeError("DB client not set for scan")
+        if not self.scan_id: raise RuntimeError("Scan id not set for scan")
+        if not self.cameras: raise RuntimeError("No Cameras connected")
+
+        self._scan_in_progress = True
+        self.scanInProgressChanged.emit(self.scan_in_progress)
+        self._scanner_working = True
+        self.scannerWorkingChanged.emit(self.scanner_working)
+
+        scan = Scan(self.cnc, self.db_client, self.cameras, self.scan_path,
+                    self.scan_id, self.config, parent=self)
+        self._bridge_scan_signals(scan)
+        try:
+            scan.scan()
+        finally:
+            self._scan_in_progress = False
+            self._scanner_working = False
+            self.scanInProgressChanged.emit(self.scan_in_progress)
+            self.scannerWorkingChanged.emit(self.scanner_working)
+            logger.info("Scan completed")
+
+    # ------------------------------------------------------------------
+    # Timelapse management
+    # ------------------------------------------------------------------
+    def start_timelapse(self, config: dict) -> str:
+        """Create and start a new :class:`TimeLapse` and return its id.
+
+        Parameters
+        ----------
+        config : dict
+            Configuration dictionary, including a ``"timelapse"`` sub-dict with
+            ``mode`` (``interval``/``fixed_times``/``one_shot``) and scheduling
+            parameters plus ``ScanPath``/``Metadata``/camera settings.
+
+        Returns
+        -------
+        str
+            The unique id of the created timelapse.
+
+        Raises
+        ------
+        RuntimeError
+            If a timelapse is already running (``SCHEDULED`` or ``RUNNING``).
+        """
+        if self.timelapse is not None and self.timelapse.state in (
+                TimeLapseState.SCHEDULED, TimeLapseState.RUNNING):
+            raise RuntimeError("A timelapse is already running")
+        name = f"tl_{datetime.datetime.now(timezone.utc):%Y_%m_%d_%H%M%S}"
+        tl = TimeLapse(
+            cnc=self.cnc,
+            db_url=self.db_url,
+            cameras=self.cameras,
+            path=self.scan_path,
+            timelapse_name=name,
+            config=config,
+            power_manager=self.power_manager,
+            parent=self,
+        )
+        # Reuse the single database connection instead of re-deriving it.
+        if self.db_client is not None:
+            tl.db_client = self.db_client
+        self._wire_timelapse(tl)
+        self.timelapse = tl
+        self.timelapseChanged.emit(tl)
+        return name
+
+    def _wire_timelapse(self, tl: TimeLapse):
+        """Forward a TimeLapse's signals to the Scanner bridge surface."""
+        tl.stateChanged.connect(self.timelapseStateChanged)
+        tl.errorOccurred.connect(self.timelapseErrorOccurred)
+        tl.scanFinished.connect(self._on_timelapse_finished)
+        tl.progressChanged.connect(self._on_timelapse_progress)
+        tl.scanCreated.connect(self._bridge_scan_signals)
+
+    def get_active_timelapse(self) -> dict | None:
+        """Return a serialisable snapshot of the active timelapse, or None."""
+        if self.timelapse is None:
+            return None
+        try:
+            store = TimelapseStore.from_timelapse(self.timelapse)
+            return store._as_serialisable_dict()
+        except Exception as exc:
+            logger.error(f"Failed to serialise active timelapse: {exc}")
+            return None
+
+    def cancel_timelapse(self) -> None:
+        """Cancel the active timelapse.
+
+        Raises
+        ------
+        RuntimeError
+            If no timelapse is active.
+        """
+        if self.timelapse is None:
+            raise RuntimeError("No active timelapse")
+        self.timelapse.cancel()
+
+    def preview_timelapse(self, config: dict) -> dict:
+        """Return the computed schedule for a config, without starting it."""
+        # Reuse TimeLapse's schedule computation by building a throwaway instance
+        # is heavy; instead expose the deterministic schedule via the store shape.
+        from plantimager.controller.scanner.timelapse import TimeLapse as _TL
+        probe = _TL(cnc=self.cnc, db_url=self.db_url, cameras=self.cameras,
+                    path=self.scan_path, timelapse_name="preview", config=config,
+                    power_manager=self.power_manager, parent=self)
+        return {
+            "mode": probe.mode.value,
+            "schedule_times": [dt.isoformat() for dt in probe.schedule_times],
+            "n_scans": probe.n_scans,
+        }
+
+    def _on_timelapse_progress(self, current: int, total: int):
+        """Forward the schedule-level (scan index / total) progress."""
+        self.timelapseProgressChanged.emit(current, total)
+
+    def _on_timelapse_finished(self):
+        """A timelapse reached a terminal state; notify the bridge."""
+        self.timelapseFinished.emit()
+
+    def _on_timelapse_scan_created(self, scan: Scan):
+        """Bridge the per-position progress of a timelapse-driven Scan."""
+        self._bridge_scan_signals(scan)
+
+    def _resume_timelapse(self):
+        """Best-effort startup resume of a previously persisted timelapse.
+
+        A full rehydrate (rebuilding a :class:`TimeLapse` from its persisted
+        schedule/config) is follow-up work. For now, a persisted **non-terminal**
+        job is logged so the operator can decide: a stale ``RUNNING`` file is
+        treated as failed per the resumption policy, and the next slot is
+        evaluated rather than blocking a fresh start.
+        """
+        try:
+            store = TimelapseStore.new_store_from_last()
+        except Exception as exc:
+            logger.warning(f"Could not read persisted timelapse for resume: {exc}")
+            return
+        if store is None:
+            return
+        logger.info(
+            f"Found persisted timelapse '{store.timelapse_id}' in state "
+            f"'{store.state}' — automatic resume construction is not yet wired "
+            f"(see dev_plan/timelapse_next.md); a stale RUNNING is treated as FAILED."
+        )
+
+    # ------------------------------------------------------------------
+    # Manual movement (CNC panel)
+    # ------------------------------------------------------------------
     def get_position(self) -> Pose:
-        """Get the current position of the scanner.
+        """Get the current position of the scanner as a 5D pose.
 
         Returns
         -------
         Pose
-            Current position as a 5D pose (x, y, z, pan, tilt)
-
-        Notes
-        -----
-        The Z and tilt values are always set to 0 as the scanner only
-        supports 3D movement (X, Y, and pan rotation).
+            Current position; z is pan, tilt is always 0.
         """
-        # Get raw position from CNC controller
         x, y, z = self.cnc.get_position()
-        # Convert to Pose object (z is pan, tilt is always 0)
         pose = Pose(x, y, 0, pan=z, tilt=0)
         return pose
 
     def set_position(self, pose: Pose) -> None:
         """Set the position of the scanner from a 5D Pose.
 
-        Parameters
-        ----------
-        pose : Pose
-            Target position as a 5D pose (x, y, z, pan, tilt)
-
         Notes
         -----
         Only X, Y, and pan values are used; Z and tilt are ignored.
-
-        Examples
-        --------
-        >>> pose = Pose(100, 100, 0, pan=45, tilt=0)
-        >>> scanner.set_position(pose)
         """
         logger.info(f"Moving arm to {pose}")
         self._scanner_working = True
@@ -583,233 +616,20 @@ class Scanner(QObject):
         self._scanner_working = False
         self.scannerWorkingChanged.emit(self.scanner_working)
 
-    def set_scan_id(self, scan_id: str):
-        """Set the identifier for the scan dataset.
-
-        Parameters
-        ----------
-        scan_id : str
-            Unique identifier for the scan in the database
-
-        Notes
-        -----
-        This ID is used when creating the scan in the database and
-        when uploading files.
-
-        Examples
-        --------
-        >>> scanner.set_scan_id("arabidopsis_001")
-        """
-        self.scan_id = scan_id  # Store the scan ID
-
-    def grab(self, idx: int, metadata: dict, camera: PiCameraComm) -> DataItem:
-        """Capture an image from a camera and upload it to the database.
-
-        This method captures an image from the specified camera, adds metadata,
-        creates a DataItem, and uploads it to the database.
-
-        Parameters
-        ----------
-        idx : int
-            Identifier for the data item to create
-        metadata : dict
-            Dictionary of metadata to associate with the image
-        camera : PiCameraComm
-            Camera object to use for capturing the image
-
-        Returns
-        -------
-        DataItem
-            The created data item containing the image and metadata
-
-        Notes
-        -----
-        The method performs these steps:
-        1. Capture image from camera
-        2. Update metadata with image information
-        3. Create a DataItem
-        4. Upload the data to the database
-
-        Examples
-        --------
-        >>> metadata = {"camera_name": "cam1", "approximate_pose": [100, 100, 0, 45, 0]}
-        >>> data_item = scanner.grab(1, metadata, camera)
-        """
-        # Capture image from camera
-        image_future = camera.getImage(lores=False)
-        buffer, buffer_info = image_future.result()  # Wait for image capture to complete
-
-        # Update metadata with image information from camera
-        metadata.update(buffer_info)
-
-        # Create data item with image and metadata
-        data = DataItem(idx, buffer, image_ext=buffer_info["format"], metadata=metadata)
-
-        # Upload data to database
-        self.uploader.upload(scan_id=self.scan_id, fileset=self.fileset, data=data)
-
-        return data
-
-    def get_target_pose(self, x: PathElement) -> Pose:
+    def get_target_pose(self, x) -> Pose:
         """Calculate the target pose from a path element.
 
-        This method creates a target pose by combining the current position
-        with the specified values from the path element. For any attribute
-        not specified in the path element, the current position value is used.
-
-        Parameters
-        ----------
-        x : PathElement
-            Path element containing the desired position attributes
-
-        Returns
-        -------
-        Pose
-            The calculated target pose
-
-        Notes
-        -----
-        If a coordinate in the path element is None, the current position
-        value for that coordinate is used instead.
+        For any attribute not specified in the path element, the current
+        position value is used.
         """
-        # Get current position
         pos = self.get_position()
-        # Create new pose
         target_pose = Pose()
-
-        # For each attribute (x, y, z, pan, tilt)
         for attr in pos.attributes():
             if getattr(x, attr) is None:
-                # If path element doesn't specify this attribute, use current position
                 setattr(target_pose, attr, getattr(pos, attr))
             else:
-                # Otherwise use the value from the path element
                 setattr(target_pose, attr, getattr(x, attr))
-
         return target_pose
-
-    def scan(self) -> None:
-        """Execute the complete scanning process.
-
-        This method performs a full scan by:
-        1. Validating that all required components are available
-        2. Creating the scan and fileset in the database
-        3. Following the scan path and capturing images at each position
-        4. Uploading all captured images with metadata
-
-        Raises
-        ------
-        RuntimeError
-            If any required component is missing
-
-        Notes
-        -----
-        - Validates all prerequisites before starting
-        - Creates scan and fileset in the database
-        - Follows the scan path, moving the CNC to each position
-        - Captures images from all cameras at each position
-        - Uploads images with position and camera metadata
-        - Uses a thread pool for parallel image capture
-        - Updates progress throughout the scan
-
-        Examples
-        --------
-        >>> scanner.set_db_url("http://localhost:5000")
-        >>> scanner.configure_scan(config_dict)
-        >>> scanner.set_scan_id("plant_scan_001")
-        >>> scanner.scan()  # Execute the scan
-        """
-        # Validate all required components are available
-        if not self.config: raise RuntimeError("Config not set for scan")
-        if not self.scan_path: raise RuntimeError("Path not set for scan")
-        if not self.db_url: raise RuntimeError("DB url not set for scan")
-        if not self.db_client: raise RuntimeError("DB client not set for scan")
-        if not self.uploader: raise RuntimeError("Uploader not set for scan")
-        if not self.scan_id: raise RuntimeError("Scan id not set for scan")
-        if not self.cameras: raise RuntimeError("No Cameras connected")
-
-        # Update metadata if using dummy CNC
-        if isinstance(self.cnc, DummyCNC):
-            self.hw_metadata["name"] = "DummyCNC"
-
-        self._scan_in_progress = True
-        self.scanInProgressChanged.emit(self.scan_in_progress)
-
-        # Create the scan on the remote database
-        try:
-            # Combine dataset and hardware metadata
-            self.db_client.create_scan(self.scan_id, metadata=self.config)
-        except RequestException as e:
-            logger.error(f"{e}")
-        except ValueError as e:
-            logger.error(f"{e}")
-            logger.error(f"Scan {self.scan_id} already exists in plantdb")
-
-        # Create the image fileset on the remote database
-        try:
-            self.db_client.create_fileset(self.fileset, self.scan_id)
-        except RequestException as e:
-            logger.error(f"{e}")
-        except ValueError as e:
-            logger.error(f"{e}")
-            logger.error(f"Fileset {self.fileset} already exists for scan {self.scan_id}")
-
-        # Execute the scan using a thread pool for parallel image capture
-        with ThreadPoolExecutor(max_workers=4) as executor:
-            shot_id = 0  # Initialize shot counter
-            self._progress = 0  # Reset progress
-
-            # Follow each point in the scan path
-            for x in self.scan_path:
-                # Update progress
-                self._progress += 1
-                self.progressChanged.emit(self._progress)
-
-                # Calculate and move to the target position
-                pose = self.get_target_pose(x)
-                self.set_position(pose)
-
-                # Get actual arm position after movement
-                arm_pose = self.get_position()
-                jobs = []  # List to track image capture jobs
-
-                # Capture images from each camera
-                for camera in self.cameras:
-                    name = camera.name
-                    # Skip cameras not in config
-                    if name not in self.config:
-                        logger.debug(f"Camera {name} not in config, skipping")
-                        continue
-
-                    # Get camera parameters and calculate camera position
-                    camera_param = self.config[name]
-                    camera_offset = Pose(**camera_param["offset"])
-                    camera_pose = arm_pose + camera_offset  # Apply offset to arm position
-
-                    # Prepare metadata for this shot
-                    metadata = {
-                        **camera_param,  # Include all camera parameters
-                        "camera_name": name,
-                        "approximate_pose": [camera_pose.x, camera_pose.y, camera_pose.z, camera_pose.pan,
-                                             camera_pose.tilt],  # Camera position
-                        "shot_id": shot_id,  # Unique ID for this shot
-                    }
-
-                    # Submit image capture job to thread pool
-                    jobs.append(executor.submit(self.grab, shot_id, metadata, camera))
-
-                shot_id += 1
-                # Wait for all image captures to complete before moving to next position
-                wait(jobs, return_when=ALL_COMPLETED)
-
-        # Move the arm back close to origin
-        # self.cnc.moveto(10, 10,-10)
-        time.sleep(1)
-        # self.cnc.home()
-        self.move_arm(20, 20, 45)
-        self._scan_in_progress = False
-        self.scanInProgressChanged.emit(self.scan_in_progress)
-        logger.info(f"Scan completed")  # Log completion
 
     @Slot(float, float, float)
     def move_arm(self, x: float, y: float, z: float):
@@ -818,7 +638,7 @@ class Scanner(QObject):
 
     @Slot()
     def move_to_center(self):
-        """Move the arm to the center"""
+        """Move the arm to the center."""
         if self.scan_path and isinstance(self.scan_path, Circle):
             self.move_arm(self.scan_path.center_x, self.scan_path.center_y, 0)
         elif self.scan_path and isinstance(self.scan_path, CalibrationPath2):
@@ -850,12 +670,3 @@ class Scanner(QObject):
         if isinstance(self.scan_path, CalibrationPath2):
             return f"{type(self.scan_path).__name__}: center {self.scan_path.center_x:g}, {self.scan_path.center_y:g}, radius {self.scan_path.radius:g} - {len(self.scan_path)} steps"
         return f"{type(self.scan_path).__name__}: {len(self.scan_path)} steps"
-
-    def set_api_token(self, token: str):
-        """Set the API token and re-create the PlantDBClient to access the plantdb server."""
-        self._api_token = token
-        if self.db_client:
-            logger.debug("Initializing PlantDBClient with API token...")
-            self.db_client = PlantDBClient(self.db_client.base_url, api_token=self._api_token)
-            self.uploader.db_client = self.db_client
-            logger.debug("Done.")

--- a/src/controller/plantimager/controller/scanner/timelapse.py
+++ b/src/controller/plantimager/controller/scanner/timelapse.py
@@ -5,22 +5,28 @@ import importlib
 import os
 import re
 import datetime
+import time
 from enum import StrEnum
 from typing import Any, Literal
 
 from PySide6.QtCore import QObject, Signal, Property, QTimer, Slot
 
+from plantimager.commons.logging import create_logger
 from plantimager.controller.camera.PiCameraComm import PiCameraComm
 from plantimager.controller.scanner.grbl import CNC
 from plantimager.controller.scanner.hal import AbstractCNC
 from plantimager.controller.scanner.path import Path
+from plantimager.controller.scanner.powermanager import PowerManager, PowerManagerMode
 from plantimager.controller.scanner.scan import Scan
 
 TIMELAPSE_FILE_PATH = os.getenv("TIMELAPSE_FILE_PATH", "./plant-imager3")
 TIMELAPSE_FILE_NAME = os.getenv("TIMELAPSE_FILE_NAME", "timelapse_storage.json")
 
+logger = create_logger(__name__)
+
 DURATION_REGEXP = re.compile(
-    r"(?:(?P<days>\d+)d)?\W?(?:(?P<hours>\d+)h)?\W?(?:(?P<minutes>\d+)m)?\W?(?P<seconds>\d+)s?")
+    r"(?:(?P<days>\d+)d)?\W?(?:(?P<hours>\d+)h)?\W?(?:(?P<minutes>\d+)m)?\W?(?P<seconds>\d+)s?"
+)
 
 
 def parse_duration(duration_string, /, duration_regexp: re.Pattern = DURATION_REGEXP):
@@ -40,6 +46,8 @@ def parse_duration(duration_string, /, duration_regexp: re.Pattern = DURATION_RE
     duration_regexp : re.Pattern, optional
         A compiled regular expression pattern used to match and extract components from
         `duration_string`. Defaults to `DURATION_REGEXP`.
+        Group Names must be keyword arguments of the datetime.timedelta objects constructor.
+        (e.g., days, hours, minutes, seconds)
 
     Returns
     -------
@@ -113,14 +121,22 @@ class TimeLapse(QObject):
     light_policy: dict  # lights mode
     scans: list[Scan]
     next_idx: int  # index of next-scheduled scan
-    state: TimeLapseState
+    current_idx: int
+    _state: TimeLapseState
     cnc: AbstractCNC
     db_url: str
     path: Path
     cameras: list[PiCameraComm]
 
+    power_manager: PowerManager
+
+    stateChanged = Signal(str)
+    progressChanged = Signal(int, int) # current progress, max progress
+    errorOccurred = Signal(str)
+    scanFinished = Signal()
+
     def __init__(self, cnc: AbstractCNC, db_url: str, cameras: list[PiCameraComm], path: Path,
-                 timelapse_name: str, config: dict[str, Any], power_manager, parent=None):
+                 timelapse_name: str, config: dict[str, Any], power_manager: PowerManager, parent=None):
         super().__init__(parent)
         self.cnc = cnc
         self.db_url = db_url
@@ -130,6 +146,90 @@ class TimeLapse(QObject):
         self.config = config
 
         # timelapse settings
+        self._setup_timelapse_settings()
+
+        # Dynamically import and instantiate the path class
+        path_module = importlib.import_module("plantimager.controller.scanner.path")
+        path_cfg = config["ScanPath"]
+        self.scan_path = getattr(path_module, path_cfg["class_name"])(**path_cfg["kwargs"])
+        self.pathInfoChanged.emit(self.path_info)
+
+        # Update progress tracking based on path length
+        self._max_progress = len(self.scan_path)
+        self.progressChanged.emit(self.current_idx, self._max_progress)
+
+        # Store metadata for the scan
+        self.dataset_metadata = config["Metadata"]["object"]  # Biological metadata
+        self.hw_metadata = config["Metadata"]["hardware"]  # Hardware metadata
+
+        # Configure cameras
+        for camera in self.cameras:
+            if camera.name in config:
+                res = config[camera.name]["res_x"], config[camera.name]["res_y"]
+                camera.resolution = res
+
+        self._state = TimeLapseState.STANDBY
+        self.power_manager = power_manager
+
+        self._next_scan_timer = QTimer(self, singleShot=True)
+        self._next_scan_timer.timeout.connect(self._trigger_next_scan)
+        self._powerup_timer = QTimer(self, singleShot=True)
+        self._powerup_timer.timeout.connect(power_manager.prepare_for_scan)
+        self._setup_next_scan_timer()
+
+    def _setup_timelapse_settings(self):
+        """
+        Configures and initializes settings for a timelapse operation.
+
+        This method sets up the internal state and scheduling parameters for
+        managing a timelapse capture, based on the configuration provided
+        in `self.config`. It supports multiple modes of operation, such as
+        `ONE_SHOT`, `INTERVAL`, and `FIXED_TIMES`, which determine the manner
+        in which photos or data are scheduled and captured.
+
+        Parameters
+        ----------
+        None
+
+        Other Parameters
+        ----------------
+        None
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        AssertionError
+            If `timelapse_config["mode"]` is not a valid `TimeLapseMode`.
+        KeyError
+            If required keys are missing in the `self.config["timelapse"]` dictionary.
+
+        Notes
+        -----
+        - The `TimeLapseMode` enum is used to determine the available modes. The
+          valid modes are checked using an assertion.
+        - For the `ONE_SHOT` mode:
+          - If the `self.cnc` attribute is an instance of `CNC`, the scheduling
+            starts immediately.
+          - Otherwise, it incorporates a warm-up period before scheduling starts.
+        - For the `INTERVAL` mode:
+          - The interval between timelapse captures is derived from the `"interval"`
+            configuration, parsed using the `parse_duration` utility.
+          - The number of shots (`"n_shots"`) determines the total number of
+            scheduled captures.
+        - For the `FIXED_TIMES` mode:
+          - Timelapse captures occur at specific dates and times, as defined by the
+            `"dates"` configuration.
+        - The `self.start_at` attribute is set to the first scheduled capture time
+          in all modes.
+
+        See Also
+        --------
+        TimeLapseMode : Enum specifying available timelapse modes.
+        parse_duration : Utility function to parse duration strings.
+        """
         timelapse_config = self.config["timelapse"]
         assert timelapse_config["mode"] in TimeLapseMode, \
             f"Unrecognized mode, expected one of {[m.value for m in TimeLapseMode]}"
@@ -137,6 +237,8 @@ class TimeLapse(QObject):
         self.warmup_sec = timelapse_config["warmup_period"]
         self.grace_period = timelapse_config["grace_period"]
         self.schedule_times = []
+        self.current_idx = 0
+        self.next_idx = 0
 
         self.mode = TimeLapseMode(timelapse_config["mode"])
         if self.mode == TimeLapseMode.ONE_SHOT:
@@ -154,44 +256,137 @@ class TimeLapse(QObject):
             n_scans = int(timelapse_config["n_shots"])
             self.schedule_times = [self.start_at + interval * i for i in range(n_scans)]
         elif self.mode == TimeLapseMode.FIXED_TIMES:
-            self.schedule_times = [datetime.datetime.fromisoformat(datestring) for datestring in timelapse_config["dates"]]
+            self.schedule_times = [datetime.datetime.fromisoformat(datestring) for datestring in
+                                   timelapse_config["dates"]]
 
         self.start_at = self.schedule_times[0]
 
-        # Dynamically import and instantiate the path class
-        path_module = importlib.import_module("plantimager.controller.scanner.path")
-        path_cfg = config["ScanPath"]
-        self.scan_path = getattr(path_module, path_cfg["class_name"])(**path_cfg["kwargs"])
-        self.pathInfoChanged.emit(self.path_info)
-
-        # Update progress tracking based on path length
-        self._max_progress = len(self.scan_path)
-        self.maxProgressChanged.emit(self._max_progress)
-
-        # Store metadata for the scan
-        self.dataset_metadata = config["Metadata"]["object"]  # Biological metadata
-        self.hw_metadata = config["Metadata"]["hardware"]  # Hardware metadata
-
-        # Configure cameras
-        for camera in self.cameras:
-            if camera.name in config:
-                res = config[camera.name]["res_x"], config[camera.name]["res_y"]
-                camera.resolution = res
-
-
-    @Slot
-    def prepare_for_scan(self):
-        pass
 
     @Slot(int)
-    def scan(self, id):
-        time = self.schedule_times[id]
+    def scan(self, index: int):
+        """
+        Executes a scheduled scan based on the provided index.
+
+        This method updates the current scanning index and triggers the `progressChanged` signal.
+        It determines the interval to the next scheduled time and either waits for the appropriate
+        time, proceeds with the scan, or skips it if the grace period has been violated.
+
+        Parameters
+        ----------
+        index : int
+            The index of the scan to execute.
+
+        Raises
+        ------
+        ValueError
+            If the provided `index` is invalid.
+
+        Notes
+        -----
+        - The method computes the interval between the current time and the next scheduled time.
+          If the interval is greater than the `grace_period`, the method pauses execution until
+          the scheduled time.
+        - If the time has already passed and exceeded the grace period, the scan is skipped.
+        - Sleeps the thread until the scheduled time arrives if the scan occurs too early.
+
+        See Also
+        --------
+        Scan.scan : Executes the actual scan process.
+
+        Examples
+        --------
+        Suppose you have a scheduler with predefined `schedule_times` and `grace_period`, you can
+        invoke the following method by supplying a valid scan index:
+
+        >>> scheduler.scan(2)
+        """
+        self.current_idx = index
+        self.progressChanged.emit(self.current_idx, self.max_progress)
+
+        next_time = self.schedule_times[self.next_idx]
+        current_time = datetime.datetime.now()
+        interval = next_time - current_time
+        if interval.total_seconds() > self.grace_period:
+            logger.warning("Woke up too early, sleeping until time.")
+            time.sleep(interval.total_seconds())
+        elif interval.total_seconds() <= -self.grace_period:
+            # date and grace period have passed
+            logger.warning(
+                f"Scan {self.next_idx} planned at {next_time.isoformat()} timed out at {current_time.isoformat()}. Skipping."
+            )
+            return
         scan = Scan(
-            self.cnc, self.db_url, self.cameras, self.path, f"{self.id}_{time.isoformat()}", self.config, parent=self
+            self.power_manager.cnc, self.db_url, self.cameras, self.path, f"{self.id}_{current_time.isoformat()}", self.config, parent=self
         )
         scan.scan()
+
+    @Slot()
+    def _trigger_next_scan(self):
+        """
+        Initiates the next scan in the scheduled timelapse sequence.
+
+        This method triggers a scan for the index specified by `next_idx`, updates
+        the index for the subsequent scan, and determines whether the timelapse sequence
+        is complete. If the timelapse is finished, the state is updated to
+        `TimeLapseState.COMPLETED`, and the `scanFinished` signal is emitted. Otherwise,
+        it sets up a timer for the next scan.
+        """
+        self.scan(self.next_idx)
+        self.next_idx += 1
+
+        # check if the timelapse is completed
+        if self.next_idx >= len(self.schedule_times):
+            self.state = TimeLapseState.COMPLETED
+            self.scanFinished.emit()
+        else:
+            self._setup_next_scan_timer()
+
+    @Slot()
+    def _powerup(self):
+        self.power_manager.mode = PowerManagerMode.SCAN
+
+    @Slot(object)
+    def cnc_ready(self, cnc):
+        self.cnc = cnc
+        self.state = TimeLapseState.STANDBY
+
+    def _setup_next_scan_timer(self):
+        """Sets up a timer for the next scheduled scan."""
+        next_time = self.schedule_times[self.next_idx]
+        current_time = datetime.datetime.now()
+        interval = next_time - current_time
+        if interval.total_seconds() > self.standby_threshold_sec:
+            self._powerup_timer.setInterval(int((interval.total_seconds() - self.warmup_sec) * 1000))
+            self._powerup_timer.start()
+            self._next_scan_timer.setInterval(int(interval.total_seconds() * 1000))
+            self._next_scan_timer.start()
+            self.power_manager.mode = PowerManagerMode.AUTO
+            self.state = TimeLapseState.COOLDOWN
+        elif interval.total_seconds() > self.grace_period:
+            self._next_scan_timer.setInterval(int(interval.total_seconds() * 1000))
+            self._next_scan_timer.start()
+            self.state = TimeLapseState.WAITING
+        else:
+            self._trigger_next_scan()
+
 
     @property
     def n_scans(self):
         return len(self.schedule_times)
 
+    @Property(str, notify=progressChanged)
+    def state(self):
+        return self._state
+    @state.setter
+    def state(self, value):
+        if self._state != value:
+            self._state = value
+            self.progressChanged.emit(self._state)
+
+    @Property(int, notify=progressChanged)
+    def progress(self):
+        return self.current_idx
+
+    @Property(int, notify=progressChanged)
+    def max_progress(self):
+        return self._max_progress

--- a/src/controller/plantimager/controller/scanner/timelapse.py
+++ b/src/controller/plantimager/controller/scanner/timelapse.py
@@ -1,20 +1,86 @@
 """
 Handles the coordination and the scheduling of multiple scans through the TimeLapse class
 """
+import importlib
 import os
-import time
+import re
+import datetime
 from enum import StrEnum
 from typing import Any, Literal
 
-from PySide6.QtCore import QObject, Signal, Property, QTimer
+from PySide6.QtCore import QObject, Signal, Property, QTimer, Slot
 
 from plantimager.controller.camera.PiCameraComm import PiCameraComm
+from plantimager.controller.scanner.grbl import CNC
 from plantimager.controller.scanner.hal import AbstractCNC
 from plantimager.controller.scanner.path import Path
 from plantimager.controller.scanner.scan import Scan
 
 TIMELAPSE_FILE_PATH = os.getenv("TIMELAPSE_FILE_PATH", "./plant-imager3")
 TIMELAPSE_FILE_NAME = os.getenv("TIMELAPSE_FILE_NAME", "timelapse_storage.json")
+
+DURATION_REGEXP = re.compile(
+    r"(?:(?P<days>\d+)d)?\W?(?:(?P<hours>\d+)h)?\W?(?:(?P<minutes>\d+)m)?\W?(?P<seconds>\d+)s?")
+
+
+def parse_duration(duration_string, /, duration_regexp: re.Pattern = DURATION_REGEXP):
+    """
+    Parses a duration string and converts it into a `datetime.timedelta` object.
+
+    This function takes a duration string in a specific format and uses a regular expression
+    pattern to extract the components (e.g., days, hours, minutes, seconds). The parsed
+    components are then converted into a `datetime.timedelta` object for further manipulation.
+
+    Parameters
+    ----------
+    duration_string : str
+        A string representing the duration in the format `Xd-Xh-Xm-Xs` (e.g., `2d-3h-1m-0s`),
+        where `X` represents integers for days, hours, minutes, and seconds. Each component
+        may be omitted if not needed (e.g., `3h-20m`).
+    duration_regexp : re.Pattern, optional
+        A compiled regular expression pattern used to match and extract components from
+        `duration_string`. Defaults to `DURATION_REGEXP`.
+
+    Returns
+    -------
+    datetime.timedelta
+        A `datetime.timedelta` object representing the parsed time duration.
+
+    Raises
+    ------
+    RuntimeError
+        If `duration_string` does not match the expected format defined by `duration_regexp`.
+
+    Notes
+    -----
+    - The `DURATION_REGEXP` constant, if used as the default `duration_regexp`, must be
+      pre-defined in the module. It should include named capturing groups for days (`d`),
+      hours (`h`), minutes (`m`), and seconds (`s`).
+
+    Examples
+    --------
+    >>> import re
+    >>> import datetime
+    >>> DURATION_REGEXP = re.compile(r'(?:(?P<days>\d+)d)?\W?(?:(?P<hours>\d+)h)?\W?(?:(?P<minutes>\d+)m)?\W?(?P<seconds>\d+)s?')
+    >>> parse_duration("2d-3h-1m-0s", duration_regexp=DURATION_REGEXP)
+    datetime.timedelta(days=2, seconds=10980)
+
+    >>> parse_duration("3h-20m", duration_regexp=DURATION_REGEXP)
+    datetime.timedelta(seconds=12000)
+
+    >>> parse_duration("invalid-string", duration_regexp=DURATION_REGEXP)
+    Traceback (most recent call last):
+    ...
+    RuntimeError: Failed to parse duration_string: invalid-string. Did not follow the format 2d-3h-1m-0s
+    """
+    match = duration_regexp.match(duration_string)
+    if match:
+        return datetime.timedelta(**{
+            k: int(v) if v else 0 for k, v in match.groupdict().items()
+        })
+    else:
+        raise RuntimeError(f"Failed to parse duration_string: {duration_string}. Did not follow the format 2d-3h-1m-0s")
+
 
 class TimeLapseMode(StrEnum):
     INTERVAL = "interval"
@@ -36,11 +102,11 @@ class TimeLapse(QObject):
 
     id: str
     mode: TimeLapseMode
-    start_at: float | None  # epoch seconds, UTC
-    end_at: float | None  # epoch seconds, UTC
-    interval_sec: int | None
-    schedule_times_utc: list[int] | None  # epoch seconds, UTC
-    max_scans: int | None
+    start_at: datetime.datetime | None
+    end_at: float | None
+    interval: datetime.timedelta | None
+    schedule_times: list[datetime.datetime] | None
+    n_scans: int | None
     warmup_sec: int  # lights/cnc warm-up
     standby_threshold_sec: int  # stay-on cutoff to next scan
     grace_period: int  # period where late starts are accepted
@@ -70,9 +136,62 @@ class TimeLapse(QObject):
 
         self.warmup_sec = timelapse_config["warmup_period"]
         self.grace_period = timelapse_config["grace_period"]
+        self.schedule_times = []
 
         self.mode = TimeLapseMode(timelapse_config["mode"])
         if self.mode == TimeLapseMode.ONE_SHOT:
-            self.start_at = time.time()
+            if isinstance(self.cnc, CNC):
+                self.schedule_times.append(datetime.datetime.now())
+            else:
+                self.schedule_times.append(datetime.datetime.now() + datetime.timedelta(seconds=self.warmup_sec))
         elif self.mode == TimeLapseMode.INTERVAL:
-            self.start_at = time.time()
+            if isinstance(self.cnc, CNC):
+                self.start_at = datetime.datetime.now()
+            else:
+                self.start_at = datetime.datetime.now() + datetime.timedelta(seconds=self.warmup_sec)
+            interval_str = timelapse_config["interval"]
+            interval = parse_duration(interval_str)
+            n_scans = int(timelapse_config["n_shots"])
+            self.schedule_times = [self.start_at + interval * i for i in range(n_scans)]
+        elif self.mode == TimeLapseMode.FIXED_TIMES:
+            self.schedule_times = [datetime.datetime.fromisoformat(datestring) for datestring in timelapse_config["dates"]]
+
+        self.start_at = self.schedule_times[0]
+
+        # Dynamically import and instantiate the path class
+        path_module = importlib.import_module("plantimager.controller.scanner.path")
+        path_cfg = config["ScanPath"]
+        self.scan_path = getattr(path_module, path_cfg["class_name"])(**path_cfg["kwargs"])
+        self.pathInfoChanged.emit(self.path_info)
+
+        # Update progress tracking based on path length
+        self._max_progress = len(self.scan_path)
+        self.maxProgressChanged.emit(self._max_progress)
+
+        # Store metadata for the scan
+        self.dataset_metadata = config["Metadata"]["object"]  # Biological metadata
+        self.hw_metadata = config["Metadata"]["hardware"]  # Hardware metadata
+
+        # Configure cameras
+        for camera in self.cameras:
+            if camera.name in config:
+                res = config[camera.name]["res_x"], config[camera.name]["res_y"]
+                camera.resolution = res
+
+
+    @Slot
+    def prepare_for_scan(self):
+        pass
+
+    @Slot(int)
+    def scan(self, id):
+        time = self.schedule_times[id]
+        scan = Scan(
+            self.cnc, self.db_url, self.cameras, self.path, f"{self.id}_{time.isoformat()}", self.config, parent=self
+        )
+        scan.scan()
+
+    @property
+    def n_scans(self):
+        return len(self.schedule_times)
+

--- a/src/controller/plantimager/controller/scanner/timelapse.py
+++ b/src/controller/plantimager/controller/scanner/timelapse.py
@@ -1,0 +1,78 @@
+"""
+Handles the coordination and the scheduling of multiple scans through the TimeLapse class
+"""
+import os
+import time
+from enum import StrEnum
+from typing import Any, Literal
+
+from PySide6.QtCore import QObject, Signal, Property, QTimer
+
+from plantimager.controller.camera.PiCameraComm import PiCameraComm
+from plantimager.controller.scanner.hal import AbstractCNC
+from plantimager.controller.scanner.path import Path
+from plantimager.controller.scanner.scan import Scan
+
+TIMELAPSE_FILE_PATH = os.getenv("TIMELAPSE_FILE_PATH", "./plant-imager3")
+TIMELAPSE_FILE_NAME = os.getenv("TIMELAPSE_FILE_NAME", "timelapse_storage.json")
+
+class TimeLapseMode(StrEnum):
+    INTERVAL = "interval"
+    FIXED_TIMES = "fixed_times"
+    ONE_SHOT = "one_shot"
+
+class TimeLapseState(StrEnum):
+    IDLE = "idle"
+    ARMING = "arming"
+    WAITING = "waiting"
+    SCANNING = "scanning"
+    STANDBY = "standby"
+    COOLDOWN = "cooldown"
+    COMPLETED = "completed"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+class TimeLapse(QObject):
+
+    id: str
+    mode: TimeLapseMode
+    start_at: float | None  # epoch seconds, UTC
+    end_at: float | None  # epoch seconds, UTC
+    interval_sec: int | None
+    schedule_times_utc: list[int] | None  # epoch seconds, UTC
+    max_scans: int | None
+    warmup_sec: int  # lights/cnc warm-up
+    standby_threshold_sec: int  # stay-on cutoff to next scan
+    grace_period: int  # period where late starts are accepted
+    light_policy: dict  # lights mode
+    scans: list[Scan]
+    next_idx: int  # index of next-scheduled scan
+    state: TimeLapseState
+    cnc: AbstractCNC
+    db_url: str
+    path: Path
+    cameras: list[PiCameraComm]
+
+    def __init__(self, cnc: AbstractCNC, db_url: str, cameras: list[PiCameraComm], path: Path,
+                 timelapse_name: str, config: dict[str, Any], power_manager, parent=None):
+        super().__init__(parent)
+        self.cnc = cnc
+        self.db_url = db_url
+        self.cameras = cameras
+        self.path = path
+        self.id = timelapse_name
+        self.config = config
+
+        # timelapse settings
+        timelapse_config = self.config["timelapse"]
+        assert timelapse_config["mode"] in TimeLapseMode, \
+            f"Unrecognized mode, expected one of {[m.value for m in TimeLapseMode]}"
+
+        self.warmup_sec = timelapse_config["warmup_period"]
+        self.grace_period = timelapse_config["grace_period"]
+
+        self.mode = TimeLapseMode(timelapse_config["mode"])
+        if self.mode == TimeLapseMode.ONE_SHOT:
+            self.start_at = time.time()
+        elif self.mode == TimeLapseMode.INTERVAL:
+            self.start_at = time.time()

--- a/src/controller/plantimager/controller/scanner/timelapse.py
+++ b/src/controller/plantimager/controller/scanner/timelapse.py
@@ -319,6 +319,7 @@ class TimeLapse(QObject):
             self.power_manager.cnc, self.db_url, self.cameras, self.path, f"{self.id}_{current_time.isoformat()}", self.config, parent=self
         )
         scan.scan()
+        self.scans.append(scan)
 
     @Slot()
     def _trigger_next_scan(self):

--- a/src/controller/plantimager/controller/scanner/timelapse.py
+++ b/src/controller/plantimager/controller/scanner/timelapse.py
@@ -192,6 +192,7 @@ class TimeLapse(QObject):
     progressChanged = Signal(int, int) # current progress, max progress
     errorOccurred = Signal(str)
     scanFinished = Signal()
+    scanCreated = Signal(object)
     pathInfoChanged = Signal(str)
 
     def __init__(self, cnc: AbstractCNC, db_url: str, cameras: list[PiCameraComm], path: Path,
@@ -388,6 +389,7 @@ class TimeLapse(QObject):
         scan_id = f"{self.id}--{self._slug_for_schedule(scheduled)}"
         scan_path = getattr(self, "scan_path", self.path)
         scan = Scan(cnc, db_client, self.cameras, scan_path, scan_id, self.config, parent=self)
+        self.scanCreated.emit(scan)
         self.state = TimeLapseState.RUNNING
         try:
             scan.scan()

--- a/src/controller/plantimager/controller/scanner/timelapse.py
+++ b/src/controller/plantimager/controller/scanner/timelapse.py
@@ -85,7 +85,7 @@ from plantdb.client.plantdb_client import PlantDBClient
 logger = create_logger(__name__)
 
 DURATION_REGEXP = re.compile(
-    r"(?:(?P<days>\d+)d)?\W?(?:(?P<hours>\d+)h)?\W?(?:(?P<minutes>\d+)m)?\W?(?P<seconds>\d+)s?"
+    r"^\s*(?:(?P<days>\d+)\s*d)?\W*(?:(?P<hours>\d+)\s*h)?\W*(?:(?P<minutes>\d+)\s*m)?\W*(?:(?P<seconds>\d+)\s*s)?\s*$"
 )
 
 
@@ -142,7 +142,7 @@ def parse_duration(duration_string, /, duration_regexp: re.Pattern = DURATION_RE
     RuntimeError: Failed to parse duration_string: invalid-string. Did not follow the format 2d-3h-1m-0s
     """
     match = duration_regexp.match(duration_string)
-    if match:
+    if match and any(v is not None for v in match.groupdict().values()):
         return datetime.timedelta(**{
             k: int(v) if v else 0 for k, v in match.groupdict().items()
         })
@@ -525,6 +525,30 @@ class TimeLapse(QObject):
         except Exception as exc:
             logger.warning(f"Failed to persist timelapse state: {exc}")
 
+
+    @Property(str, notify=pathInfoChanged)
+    def path_info(self) -> str:
+        """Human-readable description of the scan path for QML."""
+        if not hasattr(self, "scan_path") or self.scan_path is None:
+            return "No path configured"
+        # avoid hard dependency on numpy for CustomPath
+        try:
+            from plantimager.controller.scanner.path import Circle, CalibrationPath2, CustomPath
+        except Exception:
+            return f"{type(self.scan_path).__name__}: {len(self.scan_path)} steps"
+        if isinstance(self.scan_path, Circle):
+            return f"{type(self.scan_path).__name__}: center {self.scan_path.center_x:g}, {self.scan_path.center_y:g}, radius {self.scan_path.radius:g} - {len(self.scan_path)} steps"
+        if isinstance(self.scan_path, CalibrationPath2):
+            return f"{type(self.scan_path).__name__}: center {self.scan_path.center_x:g}, {self.scan_path.center_y:g}, radius {self.scan_path.radius:g} - {len(self.scan_path)} steps"
+        if isinstance(self.scan_path, CustomPath):
+            try:
+                import numpy as np
+                pts = np.array(self.scan_path)
+                x, y = float(np.mean(pts[:, 0])), float(np.mean(pts[:, 1]))
+                return f"{type(self.scan_path).__name__}: center {x:g}, {y:g} - {len(self.scan_path)} steps"
+            except Exception:
+                return f"{type(self.scan_path).__name__}: {len(self.scan_path)} steps"
+        return f"{type(self.scan_path).__name__}: {len(self.scan_path)} steps"
 
     @property
     def n_scans(self):

--- a/src/controller/plantimager/controller/scanner/timelapse.py
+++ b/src/controller/plantimager/controller/scanner/timelapse.py
@@ -1,11 +1,73 @@
 """
-Handles the coordination and the scheduling of multiple scans through the TimeLapse class
+Handles the coordination and the scheduling of multiple scans through the TimeLapse class.
+
+Call graph and state flow
+-------------------------
+
+State model (persisted via ``TimelapseStore``, ``IDLE`` = no file):
+
+    IDLE(None) ──create──▶ SCHEDULED ──scan──▶ RUNNING ──ok──▶ SCHEDULED ──▶ COMPLETED
+                              │                  │                    ▲
+                              │                  └─fail──▶ FAILED ───┘
+                              └─cancel──────────▶ CANCELLED
+
+    ``PowerManager.mode`` (``SCAN``/``AUTO``) is displayed *alongside* the timelapse state
+    in ``Scanner.qml`` — no combined ``WAITING``/``COOLDOWN`` state.
+
+Timers vs methods
+~~~~~~~~~~~~~~~~~
+.. code-block:: text
+
+    __init__
+      ├─ _setup_timelapse_settings()          # builds schedule_times (UTC internally)
+      │     ├─ ONE_SHOT:  [now (+warmup)]
+      │     ├─ INTERVAL:  [start + k*interval]  interval = parse_duration() | int
+      │     └─ FIXED_TIMES: [sorted ISO datetimes, naive→local tz→UTC]
+      └─ _setup_next_scan_timer()  ──────────────────────────────────────────┐
+                                                                             │
+    _setup_next_scan_timer()  ◀──────────────────────────────────────────────┘
+      ├─ next_idx >= len  → COMPLETED
+      ├─ delta <= -grace  → skip, next_idx++, persist, recurse
+      ├─ delta <=  grace  → QTimer.singleShot(0, _trigger_next_scan)
+      └─ delta >   grace
+           ├─ delta > standby_threshold → _powerup_timer(warmup_at) + AUTO + set_next_auto_warmup_date
+           └─ else                     → SCAN
+           └─ _next_scan_timer(delta) → SCHEDULED (persist)
+
+    _trigger_next_scan()  ← QTimer timeout or singleShot
+      ├─ scan(next_idx)  ──────────┐
+      ├─ next_idx++ + persist      │
+      └─ if done → COMPLETED else ─┘ → _setup_next_scan_timer()
+
+    scan(index)  ← _trigger_next_scan
+      ├─ validate index, delta = scheduled - now(UTC)
+      ├─ delta >  grace  → re-arm timer (no sleep)
+      ├─ delta <= -grace → skip (persist)
+      └─ else
+           ├─ state = RUNNING
+           ├─ Scan(cnc=db_client, id=f"{id}--{slug(scheduled)}", scan_path).scan()
+           ├─ state = SCHEDULED or FAILED (+ errorOccurred)
+           └─ persist
+
+    cnc_ready(cnc)  ← PowerManager.cnc_ready
+      └─ if not terminal → SCHEDULED + _setup_next_scan_timer()
+
+    _on_powerup_timer()  ← _powerup_timer timeout
+      └─ PowerManager.prepare_for_scan()  (fallback: mode=SCAN)
+
+    cancel()  ← QML / RPC
+      └─ stop timers → CANCELLED → persist → scanFinished
+
+    _persist_state()  ← every state/next_idx mutation
+      └─ TimelapseStore.from_timelapse(self).save()  (XDG, atomic mkstemp+fsync+replace)
+
+    _slug_for_schedule(dt)  helper for deterministic PlantDB scan_id.
 """
 import importlib
 import os
 import re
 import datetime
-import time
+from datetime import timezone
 from enum import StrEnum
 from typing import Any, Literal
 
@@ -18,9 +80,7 @@ from plantimager.controller.scanner.hal import AbstractCNC
 from plantimager.controller.scanner.path import Path
 from plantimager.controller.scanner.powermanager import PowerManager, PowerManagerMode
 from plantimager.controller.scanner.scan import Scan
-
-TIMELAPSE_FILE_PATH = os.getenv("TIMELAPSE_FILE_PATH", "./plant-imager3")
-TIMELAPSE_FILE_NAME = os.getenv("TIMELAPSE_FILE_NAME", "timelapse_storage.json")
+from plantdb.client.plantdb_client import PlantDBClient
 
 logger = create_logger(__name__)
 
@@ -96,14 +156,10 @@ class TimeLapseMode(StrEnum):
     ONE_SHOT = "one_shot"
 
 class TimeLapseState(StrEnum):
-    IDLE = "idle"
-    ARMING = "arming"
-    WAITING = "waiting"
-    SCANNING = "scanning"
-    STANDBY = "standby"
-    COOLDOWN = "cooldown"
+    SCHEDULED = "scheduled"
+    RUNNING = "running"
     COMPLETED = "completed"
-    ERROR = "error"
+    FAILED = "failed"
     CANCELLED = "cancelled"
 
 class TimeLapse(QObject):
@@ -125,6 +181,7 @@ class TimeLapse(QObject):
     _state: TimeLapseState
     cnc: AbstractCNC
     db_url: str
+    db_client: PlantDBClient | None
     path: Path
     cameras: list[PiCameraComm]
 
@@ -134,16 +191,21 @@ class TimeLapse(QObject):
     progressChanged = Signal(int, int) # current progress, max progress
     errorOccurred = Signal(str)
     scanFinished = Signal()
+    pathInfoChanged = Signal(str)
 
     def __init__(self, cnc: AbstractCNC, db_url: str, cameras: list[PiCameraComm], path: Path,
                  timelapse_name: str, config: dict[str, Any], power_manager: PowerManager, parent=None):
         super().__init__(parent)
         self.cnc = cnc
         self.db_url = db_url
+        self.db_client = PlantDBClient(db_url) if db_url else None
         self.cameras = cameras
         self.path = path
         self.id = timelapse_name
         self.config = config
+        self.power_manager = power_manager
+        self.scans: list[Scan] = []
+        self._state = TimeLapseState.SCHEDULED
 
         # timelapse settings
         self._setup_timelapse_settings()
@@ -168,13 +230,10 @@ class TimeLapse(QObject):
                 res = config[camera.name]["res_x"], config[camera.name]["res_y"]
                 camera.resolution = res
 
-        self._state = TimeLapseState.STANDBY
-        self.power_manager = power_manager
-
         self._next_scan_timer = QTimer(self, singleShot=True)
         self._next_scan_timer.timeout.connect(self._trigger_next_scan)
         self._powerup_timer = QTimer(self, singleShot=True)
-        self._powerup_timer.timeout.connect(power_manager.prepare_for_scan)
+        self._powerup_timer.timeout.connect(self._on_powerup_timer)
         self._setup_next_scan_timer()
 
     def _setup_timelapse_settings(self):
@@ -234,155 +293,259 @@ class TimeLapse(QObject):
         assert timelapse_config["mode"] in TimeLapseMode, \
             f"Unrecognized mode, expected one of {[m.value for m in TimeLapseMode]}"
 
-        self.warmup_sec = timelapse_config["warmup_period"]
-        self.grace_period = timelapse_config["grace_period"]
+        self.warmup_sec = int(timelapse_config.get("warmup_period", 30))
+        self.grace_period = int(timelapse_config.get("grace_period", 120))
+        self.standby_threshold_sec = int(timelapse_config.get("standby_threshold_sec", 600))
+        self.light_policy = timelapse_config.get("light_policy", {})
         self.schedule_times = []
         self.current_idx = 0
         self.next_idx = 0
 
         self.mode = TimeLapseMode(timelapse_config["mode"])
+        now_utc = datetime.datetime.now(timezone.utc)
         if self.mode == TimeLapseMode.ONE_SHOT:
             if isinstance(self.cnc, CNC):
-                self.schedule_times.append(datetime.datetime.now())
+                self.schedule_times.append(now_utc)
             else:
-                self.schedule_times.append(datetime.datetime.now() + datetime.timedelta(seconds=self.warmup_sec))
+                self.schedule_times.append(now_utc + datetime.timedelta(seconds=self.warmup_sec))
         elif self.mode == TimeLapseMode.INTERVAL:
             if isinstance(self.cnc, CNC):
-                self.start_at = datetime.datetime.now()
+                self.start_at = now_utc
             else:
-                self.start_at = datetime.datetime.now() + datetime.timedelta(seconds=self.warmup_sec)
-            interval_str = timelapse_config["interval"]
-            interval = parse_duration(interval_str)
+                self.start_at = now_utc + datetime.timedelta(seconds=self.warmup_sec)
+            interval_raw = timelapse_config["interval"]
+            if isinstance(interval_raw, int):
+                interval = datetime.timedelta(seconds=interval_raw)
+            else:
+                interval = parse_duration(str(interval_raw))
             n_scans = int(timelapse_config["n_shots"])
             self.schedule_times = [self.start_at + interval * i for i in range(n_scans)]
         elif self.mode == TimeLapseMode.FIXED_TIMES:
-            self.schedule_times = [datetime.datetime.fromisoformat(datestring) for datestring in
-                                   timelapse_config["dates"]]
+            parsed = []
+            local_tz = datetime.datetime.now().astimezone().tzinfo
+            for datestring in timelapse_config["dates"]:
+                dt = datetime.datetime.fromisoformat(datestring)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=local_tz)
+                dt = dt.astimezone(timezone.utc)
+                parsed.append(dt)
+            self.schedule_times = sorted(parsed)
 
-        self.start_at = self.schedule_times[0]
+        self.start_at = self.schedule_times[0] if self.schedule_times else None
 
+
+    def _slug_for_schedule(self, scheduled: datetime.datetime) -> str:
+        """Deterministic, FSDB-safe slug for a scheduled time (UTC ISO, ``:``→``-``)."""
+        iso = scheduled.astimezone(timezone.utc).isoformat(timespec="seconds")
+        return iso.replace(":", "-").replace("+", "_")
 
     @Slot(int)
     def scan(self, index: int):
         """
-        Executes a scheduled scan based on the provided index.
+        Executes the scan at ``schedule_times[index]`` (UTC, deterministic ``scan_id``).
 
-        This method updates the current scanning index and triggers the `progressChanged` signal.
-        It determines the interval to the next scheduled time and either waits for the appropriate
-        time, proceeds with the scan, or skips it if the grace period has been violated.
+        Grace/warmup is handled by ``_setup_next_scan_timer``; this method never
+        blocks. If called early (``delta > grace``) it re-arms the timer; if
+        ``delta <= -grace`` the scan is skipped per persistence policy (one
+        dataset per time, ``skip`` without catch-up). Otherwise creates a
+        ``Scan`` with ``f"{id}--{slug(scheduled)}"`` and runs it synchronously,
+        transitioning ``SCHEDULED → RUNNING → SCHEDULED`` (or ``FAILED``).
 
         Parameters
         ----------
         index : int
-            The index of the scan to execute.
+            Index in ``schedule_times``; must equal ``next_idx``.
 
         Raises
         ------
         ValueError
-            If the provided `index` is invalid.
-
-        Notes
-        -----
-        - The method computes the interval between the current time and the next scheduled time.
-          If the interval is greater than the `grace_period`, the method pauses execution until
-          the scheduled time.
-        - If the time has already passed and exceeded the grace period, the scan is skipped.
-        - Sleeps the thread until the scheduled time arrives if the scan occurs too early.
-
-        See Also
-        --------
-        Scan.scan : Executes the actual scan process.
-
-        Examples
-        --------
-        Suppose you have a scheduler with predefined `schedule_times` and `grace_period`, you can
-        invoke the following method by supplying a valid scan index:
-
-        >>> scheduler.scan(2)
+            If ``index`` is out of range.
         """
+        if index < 0 or index >= len(self.schedule_times):
+            raise ValueError(f"Invalid scan index {index}")
         self.current_idx = index
-        self.progressChanged.emit(self.current_idx, self.max_progress)
+        self.progressChanged.emit(self.current_idx, self._max_progress)
 
-        next_time = self.schedule_times[self.next_idx]
-        current_time = datetime.datetime.now()
-        interval = next_time - current_time
-        if interval.total_seconds() > self.grace_period:
-            logger.warning("Woke up too early, sleeping until time.")
-            time.sleep(interval.total_seconds())
-        elif interval.total_seconds() <= -self.grace_period:
-            # date and grace period have passed
-            logger.warning(
-                f"Scan {self.next_idx} planned at {next_time.isoformat()} timed out at {current_time.isoformat()}. Skipping."
-            )
+        scheduled = self.schedule_times[self.next_idx]
+        now = datetime.datetime.now(timezone.utc)
+        delta = (scheduled - now).total_seconds()
+
+        if delta > self.grace_period:
+            logger.warning(f"Woke up {delta:.1f}s early for scan {self.next_idx} at {scheduled.isoformat()}, re-arming timer.")
+            self._setup_next_scan_timer()
             return
-        scan = Scan(
-            self.power_manager.cnc, self.db_url, self.cameras, self.path, f"{self.id}_{current_time.isoformat()}", self.config, parent=self
-        )
-        scan.scan()
-        self.scans.append(scan)
+
+        if delta <= -self.grace_period:
+            logger.warning(
+                f"Scan {self.next_idx} planned at {scheduled.isoformat()} missed (now {now.isoformat()}, grace {self.grace_period}s). Skipping per policy."
+            )
+            self._persist_state()
+            return
+
+        cnc = self.power_manager.get_cnc() if self.power_manager else self.cnc
+        if cnc is None:
+            cnc = self.cnc
+        db_client = self.db_client or PlantDBClient(self.db_url) if self.db_url else None
+        scan_id = f"{self.id}--{self._slug_for_schedule(scheduled)}"
+        scan_path = getattr(self, "scan_path", self.path)
+        scan = Scan(cnc, db_client, self.cameras, scan_path, scan_id, self.config, parent=self)
+        prev_state = self._state
+        self.state = TimeLapseState.RUNNING
+        try:
+            scan.scan()
+            self.scans.append(scan)
+        except Exception as exc:
+            logger.error(f"Scan {self.next_idx} {scan_id} failed: {exc}")
+            self.scans.append(scan)
+            self.state = TimeLapseState.FAILED
+            self.errorOccurred.emit(str(exc))
+            self._persist_state()
+            raise
+        finally:
+            if self._state == TimeLapseState.RUNNING:
+                self.state = TimeLapseState.SCHEDULED
+        self._persist_state()
 
     @Slot()
     def _trigger_next_scan(self):
         """
-        Initiates the next scan in the scheduled timelapse sequence.
+        Initiates the scan at ``next_idx`` and advances the schedule.
 
-        This method triggers a scan for the index specified by `next_idx`, updates
-        the index for the subsequent scan, and determines whether the timelapse sequence
-        is complete. If the timelapse is finished, the state is updated to
-        `TimeLapseState.COMPLETED`, and the `scanFinished` signal is emitted. Otherwise,
-        it sets up a timer for the next scan.
+        Called by ``_next_scan_timer`` or a zero-delay ``singleShot`` from
+        ``_setup_next_scan_timer``. Wraps ``scan()`` (skipped scans do not
+        raise), increments ``next_idx``, persists, and either completes
+        (``COMPLETED`` + ``scanFinished``) or re-arms via
+        ``_setup_next_scan_timer``.
         """
-        self.scan(self.next_idx)
+        try:
+            self.scan(self.next_idx)
+        except Exception:
+            pass
         self.next_idx += 1
-
-        # check if the timelapse is completed
+        self._persist_state()
         if self.next_idx >= len(self.schedule_times):
             self.state = TimeLapseState.COMPLETED
             self.scanFinished.emit()
+            self._persist_state()
+            self._next_scan_timer.stop()
+            self._powerup_timer.stop()
         else:
             self._setup_next_scan_timer()
 
     @Slot()
     def _powerup(self):
+        """Immediate power-up helper for manual controls (QML)."""
         self.power_manager.mode = PowerManagerMode.SCAN
+
+    @Slot()
+    def _on_powerup_timer(self):
+        """Warm-up timer callback — delegates to ``PowerManager``."""
+        if self.power_manager:
+            try:
+                self.power_manager.prepare_for_scan()
+            except AttributeError:
+                self.power_manager.mode = PowerManagerMode.SCAN
 
     @Slot(object)
     def cnc_ready(self, cnc):
+        """PowerManager reports CNC connected; (re)arm schedule if not terminal."""
         self.cnc = cnc
-        self.state = TimeLapseState.STANDBY
+        if self._state not in (TimeLapseState.COMPLETED, TimeLapseState.FAILED, TimeLapseState.CANCELLED):
+            self.state = TimeLapseState.SCHEDULED
+            self._setup_next_scan_timer()
 
     def _setup_next_scan_timer(self):
-        """Sets up a timer for the next scheduled scan."""
+        """
+        Arms ``_next_scan_timer`` (and ``_powerup_timer``) for ``schedule_times[next_idx]``.
+
+        Handles ``skip`` for overdue entries (``delta <= -grace``), immediate
+        dispatch when inside the grace window (``delta <= grace``), and
+        power-aware scheduling otherwise. Power state is kept in
+        ``PowerManager.mode`` and shown alongside the timelapse state in QML.
+        """
+        if self.next_idx >= len(self.schedule_times):
+            self.state = TimeLapseState.COMPLETED
+            return
         next_time = self.schedule_times[self.next_idx]
-        current_time = datetime.datetime.now()
-        interval = next_time - current_time
-        if interval.total_seconds() > self.standby_threshold_sec:
-            self._powerup_timer.setInterval(int((interval.total_seconds() - self.warmup_sec) * 1000))
+        if next_time.tzinfo is None:
+            next_time = next_time.replace(tzinfo=timezone.utc)
+        now = datetime.datetime.now(timezone.utc)
+        delta = (next_time - now).total_seconds()
+
+        if delta <= -self.grace_period:
+            logger.warning(f"Scan {self.next_idx} already missed by {-delta:.1f}s, skipping.")
+            self.next_idx += 1
+            self._persist_state()
+            if self.next_idx >= len(self.schedule_times):
+                self.state = TimeLapseState.COMPLETED
+                self.scanFinished.emit()
+                return
+            self._setup_next_scan_timer()
+            return
+
+        if delta <= self.grace_period:
+            QTimer.singleShot(0, self._trigger_next_scan)
+            return
+
+        self._next_scan_timer.stop()
+        self._powerup_timer.stop()
+
+        warmup_at = max(0, delta - self.warmup_sec)
+        if delta > self.standby_threshold_sec:
+            self._powerup_timer.setInterval(int(warmup_at * 1000))
             self._powerup_timer.start()
-            self._next_scan_timer.setInterval(int(interval.total_seconds() * 1000))
-            self._next_scan_timer.start()
-            self.power_manager.mode = PowerManagerMode.AUTO
-            self.state = TimeLapseState.COOLDOWN
-        elif interval.total_seconds() > self.grace_period:
-            self._next_scan_timer.setInterval(int(interval.total_seconds() * 1000))
-            self._next_scan_timer.start()
-            self.state = TimeLapseState.WAITING
+            if self.power_manager:
+                self.power_manager.mode = PowerManagerMode.AUTO
+                try:
+                    self.power_manager.set_next_auto_warmup_date(next_time - datetime.timedelta(seconds=self.warmup_sec))
+                except Exception:
+                    pass
         else:
-            self._trigger_next_scan()
+            if self.power_manager:
+                self.power_manager.mode = PowerManagerMode.SCAN
+        self._next_scan_timer.setInterval(int(delta * 1000))
+        self._next_scan_timer.start()
+        self.state = TimeLapseState.SCHEDULED
+        self._persist_state()
+
+    def cancel(self):
+        """Cancels the timelapse, stops timers, persists ``CANCELLED``."""
+        self._next_scan_timer.stop()
+        self._powerup_timer.stop()
+        self.state = TimeLapseState.CANCELLED
+        self._persist_state()
+        self.scanFinished.emit()
+
+    def _persist_state(self):
+        """Persists current state via ``TimelapseStore`` (atomic XDG save)."""
+        try:
+            from plantimager.controller.scanner.timelapse_store import TimelapseStore
+            store = TimelapseStore.from_timelapse(self)
+            store.save()
+        except Exception as exc:
+            logger.warning(f"Failed to persist timelapse state: {exc}")
 
 
     @property
     def n_scans(self):
         return len(self.schedule_times)
 
-    @Property(str, notify=progressChanged)
+    @Property(str, notify=stateChanged)
     def state(self):
+        """Current timelapse state, QML-visible via ``stateChanged``.
+
+        Separate from ``PowerManager.mode`` which is displayed alongside
+        in ``Scanner.qml``.
+        """
         return self._state
+
     @state.setter
     def state(self, value):
+        if isinstance(value, str):
+            value = TimeLapseState(value)
         if self._state != value:
             self._state = value
-            self.progressChanged.emit(self._state)
+            self.stateChanged.emit(value.value if isinstance(value, TimeLapseState) else str(value))
 
     @Property(int, notify=progressChanged)
     def progress(self):

--- a/src/controller/plantimager/controller/scanner/timelapse.py
+++ b/src/controller/plantimager/controller/scanner/timelapse.py
@@ -30,8 +30,8 @@ Timers vs methods
       ├─ delta <= -grace  → skip, next_idx++, persist, recurse
       ├─ delta <=  grace  → QTimer.singleShot(0, _trigger_next_scan)
       └─ delta >   grace
-           ├─ delta > standby_threshold → _powerup_timer(warmup_at) + AUTO + set_next_auto_warmup_date
-           └─ else                     → SCAN
+           ├─ PowerManager.arm_for_scan(next_time, standby_threshold_sec)
+           │     (PowerManager decides AUTO/SCAN + arms its own warm-up timer)
            └─ _next_scan_timer(delta) → SCHEDULED (persist)
 
     _trigger_next_scan()  ← QTimer timeout or singleShot
@@ -52,11 +52,12 @@ Timers vs methods
     cnc_ready(cnc)  ← PowerManager.cnc_ready
       └─ if not terminal → SCHEDULED + _setup_next_scan_timer()
 
-    _on_powerup_timer()  ← _powerup_timer timeout
-      └─ PowerManager.prepare_for_scan()  (fallback: mode=SCAN)
-
     cancel()  ← QML / RPC
       └─ stop timers → CANCELLED → persist → scanFinished
+
+    Power owns only ``PowerManager``: the warm-up timer and the AUTO/SCAN
+    decision live in ``PowerManager.arm_for_scan()``; ``TimeLapse`` merely
+    informs it of the next scan time.
 
     _persist_state()  ← every state/next_idx mutation
       └─ TimelapseStore.from_timelapse(self).save()  (XDG, atomic mkstemp+fsync+replace)
@@ -78,7 +79,7 @@ from plantimager.controller.camera.PiCameraComm import PiCameraComm
 from plantimager.controller.scanner.grbl import CNC
 from plantimager.controller.scanner.hal import AbstractCNC
 from plantimager.controller.scanner.path import Path
-from plantimager.controller.scanner.powermanager import PowerManager, PowerManagerMode
+from plantimager.controller.scanner.powermanager import PowerManager
 from plantimager.controller.scanner.scan import Scan
 from plantdb.client.plantdb_client import PlantDBClient
 
@@ -232,8 +233,6 @@ class TimeLapse(QObject):
 
         self._next_scan_timer = QTimer(self, singleShot=True)
         self._next_scan_timer.timeout.connect(self._trigger_next_scan)
-        self._powerup_timer = QTimer(self, singleShot=True)
-        self._powerup_timer.timeout.connect(self._on_powerup_timer)
         self._setup_next_scan_timer()
 
     def _setup_timelapse_settings(self):
@@ -389,7 +388,6 @@ class TimeLapse(QObject):
         scan_id = f"{self.id}--{self._slug_for_schedule(scheduled)}"
         scan_path = getattr(self, "scan_path", self.path)
         scan = Scan(cnc, db_client, self.cameras, scan_path, scan_id, self.config, parent=self)
-        prev_state = self._state
         self.state = TimeLapseState.RUNNING
         try:
             scan.scan()
@@ -428,23 +426,8 @@ class TimeLapse(QObject):
             self.scanFinished.emit()
             self._persist_state()
             self._next_scan_timer.stop()
-            self._powerup_timer.stop()
         else:
             self._setup_next_scan_timer()
-
-    @Slot()
-    def _powerup(self):
-        """Immediate power-up helper for manual controls (QML)."""
-        self.power_manager.mode = PowerManagerMode.SCAN
-
-    @Slot()
-    def _on_powerup_timer(self):
-        """Warm-up timer callback — delegates to ``PowerManager``."""
-        if self.power_manager:
-            try:
-                self.power_manager.prepare_for_scan()
-            except AttributeError:
-                self.power_manager.mode = PowerManagerMode.SCAN
 
     @Slot(object)
     def cnc_ready(self, cnc):
@@ -456,12 +439,14 @@ class TimeLapse(QObject):
 
     def _setup_next_scan_timer(self):
         """
-        Arms ``_next_scan_timer`` (and ``_powerup_timer``) for ``schedule_times[next_idx]``.
+        Arms ``_next_scan_timer`` for ``schedule_times[next_idx]`` and informs
+        ``PowerManager`` of the next scan time.
 
         Handles ``skip`` for overdue entries (``delta <= -grace``), immediate
-        dispatch when inside the grace window (``delta <= grace``), and
-        power-aware scheduling otherwise. Power state is kept in
-        ``PowerManager.mode`` and shown alongside the timelapse state in QML.
+        dispatch when inside the grace window (``delta <= grace``), and power-aware
+        scheduling otherwise. Power is delegated to ``PowerManager.arm_for_scan``
+        (which decides AUTO/SCAN and arms its own warm-up timer); only the scan
+        trigger timer lives here.
         """
         if self.next_idx >= len(self.schedule_times):
             self.state = TimeLapseState.COMPLETED
@@ -488,21 +473,10 @@ class TimeLapse(QObject):
             return
 
         self._next_scan_timer.stop()
-        self._powerup_timer.stop()
 
-        warmup_at = max(0, delta - self.warmup_sec)
-        if delta > self.standby_threshold_sec:
-            self._powerup_timer.setInterval(int(warmup_at * 1000))
-            self._powerup_timer.start()
-            if self.power_manager:
-                self.power_manager.mode = PowerManagerMode.AUTO
-                try:
-                    self.power_manager.set_next_auto_warmup_date(next_time - datetime.timedelta(seconds=self.warmup_sec))
-                except Exception:
-                    pass
-        else:
-            if self.power_manager:
-                self.power_manager.mode = PowerManagerMode.SCAN
+        if self.power_manager:
+            self.power_manager.arm_for_scan(next_time, self.standby_threshold_sec)
+
         self._next_scan_timer.setInterval(int(delta * 1000))
         self._next_scan_timer.start()
         self.state = TimeLapseState.SCHEDULED
@@ -511,7 +485,6 @@ class TimeLapse(QObject):
     def cancel(self):
         """Cancels the timelapse, stops timers, persists ``CANCELLED``."""
         self._next_scan_timer.stop()
-        self._powerup_timer.stop()
         self.state = TimeLapseState.CANCELLED
         self._persist_state()
         self.scanFinished.emit()

--- a/src/controller/plantimager/controller/scanner/timelapse_store.py
+++ b/src/controller/plantimager/controller/scanner/timelapse_store.py
@@ -1,0 +1,249 @@
+import json
+import os
+import pathlib
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Dict, List, Optional
+
+from plantimager.commons.logging import create_logger
+
+TIMELAPSE_STORAGE_JSON = "timelapse_storage.json"
+
+logger = create_logger(__name__)
+
+def get_storage_dir() -> pathlib.Path:
+    """Return the path to the storage directory at ``~/.local/share/plant-imager3-app``"""
+    return pathlib.Path(os.getenv("XDG_DATA_HOME", pathlib.Path.home() / ".local" / "share")) / "plant-imager3-app"
+
+# ----------------------------------------------------------------------
+# Helper functions – JSON‑serialisation of non‑primitive types
+# ----------------------------------------------------------------------
+def _dt_to_iso(dt: Optional[datetime]) -> Optional[str]:
+    return dt.isoformat() if dt is not None else None
+
+
+def _iso_to_dt(s: Optional[str]) -> Optional[datetime]:
+    return datetime.fromisoformat(s) if s is not None else None
+
+
+def _enum_to_str(e: Optional[StrEnum]) -> Optional[str]:
+    return e.value if e is not None else None
+
+
+def _str_to_enum(cls: Any, s: Optional[str]) -> Optional[StrEnum]:
+    return cls(s) if s is not None else None
+
+
+# ----------------------------------------------------------------------
+# Minimal representation of a finished Scan
+# ----------------------------------------------------------------------
+@dataclass
+class ScanRecord:
+    """Only the data needed to resume/re‑run a timelapse."""
+    scan_id: str
+    started_at: Optional[str] = None   # ISO‑8601
+    finished_at: Optional[str] = None  # ISO‑8601
+    status: str = "pending"             # "succeeded", "failed", "skipped", …
+    error: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_scan(cls, scan_obj: Any) -> "ScanRecord":
+        """Create a record from a live `Scan` instance."""
+        # The real Scan class already stores timestamps as floats;
+        # we convert them to ISO strings for readability.
+        return cls(
+            scan_id=scan_obj.scan_id,
+            started_at=_dt_to_iso(
+                datetime.fromtimestamp(scan_obj._start_time) if getattr(scan_obj, "_start_time", None) else None
+            ),
+            finished_at=_dt_to_iso(
+                datetime.fromtimestamp(scan_obj._stop_time) if getattr(scan_obj, "_stop_time", None) else None
+            ),
+            status=getattr(scan_obj, "status", "pending"),
+            error=getattr(scan_obj, "error", None),
+        )
+
+
+# ----------------------------------------------------------------------
+# The JSON‑backed store
+# ----------------------------------------------------------------------
+@dataclass
+class TimelapseStore:
+    """Encapsulates atomic persistence of a TimeLapse object."""
+    _file_name: str = os.getenv("PI3_TIMELAPSE_FILE_NAME", TIMELAPSE_STORAGE_JSON)
+    version: int = 1
+
+    # The fields below are written to / read from JSON
+    timelapse_id: str = ""
+    mode: str = ""
+    state: str = ""
+    schedule_times: List[str] = field(default_factory=list)      # ISO strings
+    next_idx: int = 0
+    current_idx: int = 0
+    warmup_sec: int = 0
+    standby_threshold_sec: int = 0
+    grace_period: int = 0
+    start_at: Optional[str] = None
+    scans: List[Dict[str, Any]] = field(default_factory=list)   # list of ScanRecord dicts
+    extra: Dict[str, Any] = field(default_factory=dict)        # any additional blob the caller wants to keep
+
+    # ------------------------------------------------------------------
+    # Path handling
+    # ------------------------------------------------------------------
+    @property
+    def _full_path(self) -> pathlib.Path:
+        return get_storage_dir() / self._file_name
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+    def _as_serialisable_dict(self) -> Dict[str, Any]:
+        """Return a plain‑dict ready for json.dump()."""
+        data = {}
+        for key, value in asdict(self).items():
+            if not key.startswith("_"):  # remove private attributes
+                data[key] = value
+        return data
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def save(self) -> None:
+        """Write the current state to disk atomically."""
+        try:
+            get_storage_dir().mkdir(parents=True, exist_ok=True)
+
+            # Write to a temporary file in the same directory (rename is atomic on POSIX)
+            fd, tmp_path = tempfile.mkstemp(dir=get_storage_dir(), prefix=self._file_name, suffix=".tmp")
+            with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+                json.dump(self._as_serialisable_dict(), tmp_file, indent=2, sort_keys=True)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+
+            # Replace the old file
+            tmp_path_obj = pathlib.Path(tmp_path)
+            tmp_path_obj.replace(self._full_path)
+            logger.debug(f"Timelapse state saved to {self._full_path}")
+        except Exception as exc:
+            logger.error(f"Failed to save timelapse state: {exc}")
+            raise
+
+    @classmethod
+    def new_store_from_last(cls) -> Optional["TimelapseStore"]:
+        """
+        Load a `TimelapseStore` instance from a stored JSON file in the storage directory.
+
+        This method attempts to recreate a `TimelapseStore` object from a persisted state
+        stored in a JSON file. If the JSON file cannot be found or is invalid, the method
+        logs the issue and returns `None`. In case of a version mismatch between the stored
+        data and the current implementation, the method attempts a best-effort loading process.
+
+        Returns
+        -------
+        Optional[TimelapseStore]
+            A `TimelapseStore` instance reconstructed from the JSON file if successful;
+            otherwise, `None`.
+
+        Notes
+        -----
+        - The JSON file' is located at ``~/.local/share/plant-imager3-app/$PI3_TIMELAPSE_FILE_NAME``.
+        If the environment variable is not set, it defaults to `"timelapse_storage.json"`.
+        - A basic version check is performed to ensure backward compatibility. If a version
+          mismatch is detected, a warning is logged, and the loading process continues on a
+          best-effort basis.
+        - Any exception encountered during file reading or JSON parsing will be caught, and
+          a corresponding error message will be logged.
+        """
+        store_path = get_storage_dir() / os.getenv(
+            "PI3_TIMELAPSE_FILE_NAME", TIMELAPSE_STORAGE_JSON
+        )
+        if not store_path.is_file():
+            logger.info("No persisted timelapse file found – starting fresh.")
+            return None
+
+        try:
+            with store_path.open("r", encoding="utf-8") as f:
+                raw = json.load(f)
+
+            # Basic version check – allow future‑compatible extensions
+            if raw.get("version", 1) != cls().version:
+                logger.warning("Timelapse file version mismatch; attempting best‑effort load.")
+
+            # Build the object
+            obj = cls(
+                timelapse_id=raw.get("timelapse_id", ""),
+                mode=raw.get("mode", ""),
+                state=raw.get("state", ""),
+                schedule_times=raw.get("schedule_times", []),
+                next_idx=raw.get("next_idx", 0),
+                current_idx=raw.get("current_idx", 0),
+                warmup_sec=raw.get("warmup_sec", 0),
+                standby_threshold_sec=raw.get("standby_threshold_sec", 0),
+                grace_period=raw.get("grace_period", 0),
+                start_at=raw.get("start_at"),
+                scans=raw.get("scans", []),
+                extra=raw.get("extra", {}),
+                version=raw.get("version", 1),
+            )
+            logger.debug(f"Timelapse state loaded from {store_path}")
+            return obj
+        except Exception as exc:
+            logger.error(f"Failed to read timelapse state: {exc}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Convenience helpers for the TimeLapse class
+    # ------------------------------------------------------------------
+    def to_timelapse_kwargs(self) -> Dict[str, Any]:
+        """
+        Convert the stored JSON into a dict that can be fed to a new
+        `TimeLapse` instance for a quick “resume” path.
+        """
+        # Convert ISO strings back to datetime objects where required.
+        schedule = [_iso_to_dt(s) for s in self.schedule_times]
+        start = _iso_to_dt(self.start_at)
+
+        return {
+            "timelapse_id": self.timelapse_id,
+            "mode": self.mode,
+            "state": self.state,
+            "schedule_times": schedule,
+            "next_idx": self.next_idx,
+            "current_idx": self.current_idx,
+            "warmup_sec": self.warmup_sec,
+            "standby_threshold_sec": self.standby_threshold_sec,
+            "grace_period": self.grace_period,
+            "start_at": start,
+            "scans": [ScanRecord(**s) for s in self.scans],
+            "extra": self.extra,
+        }
+
+    @staticmethod
+    def from_timelapse(tl_obj: Any) -> "TimelapseStore":
+        """
+        Create a store instance from a *live* TimeLapse object.
+        Only the fields that are required for a restart are persisted.
+        """
+        # Serialize schedule_times as ISO strings
+        schedule_iso = [_dt_to_iso(dt) for dt in tl_obj.schedule_times]
+
+        # Build thin ScanRecord objects – we avoid persisting the whole Scan
+        # to keep the JSON small and independent of heavy objects.
+        scan_records = [asdict(ScanRecord.from_scan(s)) for s in getattr(tl_obj, "scans", [])]
+
+        return TimelapseStore(
+            timelapse_id=tl_obj.id,
+            mode=_enum_to_str(tl_obj.mode),
+            state=_enum_to_str(tl_obj._state),
+            schedule_times=schedule_iso,
+            next_idx=tl_obj.next_idx,
+            current_idx=tl_obj.current_idx,
+            warmup_sec=tl_obj.warmup_sec,
+            standby_threshold_sec=tl_obj.standby_threshold_sec,
+            grace_period=tl_obj.grace_period,
+            start_at=_dt_to_iso(tl_obj.start_at),
+            scans=scan_records,
+            extra={},
+        )

--- a/src/controller/pyproject.toml
+++ b/src/controller/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "scikit-image",
     "numpy",
     "plantimager.commons",
+    "gpio",
 ]
 description = "A Qt-based interface turning a Raspberry Pi 4/5 into the main controller of the ROMI Plant Imager."
 readme = "README.md"

--- a/test/test_powermanager.py
+++ b/test/test_powermanager.py
@@ -1,0 +1,124 @@
+# test_powermanager.py
+import unittest
+from unittest.mock import MagicMock, patch
+
+# The PowerManager implementation is assumed to be importable from a module
+# named ``power_manager`` that resides in the same package as this test file.
+# Adjust the import if the actual module path differs.
+from plantimager.controller.scanner.powermanager import PowerManager, PowerManagerMode
+
+
+class FakeTimer:
+    """
+    Minimal stand‑in for ``QTimer`` used by PowerManager.
+    Only the parts accessed by the tests are implemented.
+    """
+    def __init__(self, parent=None, singleShot=False, interval=0):
+        self._single_shot = singleShot
+        self.interval = interval
+        self.timeout = MagicMock()
+        self._started = False
+
+    def start(self):
+        self._started = True
+
+    def stop(self):
+        self._started = False
+
+    def isActive(self):
+        return self._started
+
+
+class PowerManagerTest(unittest.TestCase):
+    def setUp(self):
+        # Patch external dependencies before creating a PowerManager instance
+        self.gpio_setup_patcher = patch('plantimager.controller.scanner.powermanager.gpio.setup')
+        self.gpio_write_patcher = patch('plantimager.controller.scanner.powermanager.gpio.write')
+        self.cnc_patcher = patch('plantimager.controller.scanner.powermanager.CNC')
+        self.qtimer_patcher = patch('plantimager.controller.scanner.powermanager.QTimer', side_effect=FakeTimer)
+
+        self.mock_gpio_setup = self.gpio_setup_patcher.start()
+        self.mock_gpio_write = self.gpio_write_patcher.start()
+        self.mock_cnc_class = self.cnc_patcher.start()
+        self.mock_qtimer = self.qtimer_patcher.start()
+
+        # Use a small warm‑up period to keep the maths straightforward
+        self.pm = PowerManager(warmup_period=60.0)   # 60 seconds
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_initial_mode_is_auto(self):
+        self.assertEqual(self.pm.mode, PowerManagerMode.AUTO)
+
+    def test_mode_change_calls_correct_helpers(self):
+        # Replace the private helpers with mocks so we can assert they are called
+        self.pm._prepare_for_scan = MagicMock()
+        self.pm._resume_auto = MagicMock()
+
+        # Switch to SCAN – should call _prepare_for_scan
+        self.pm.mode = PowerManagerMode.SCAN
+        self.pm._prepare_for_scan.assert_called_once()
+        self.pm._resume_auto.assert_not_called()
+        self.assertEqual(self.pm.mode, PowerManagerMode.SCAN)
+
+        # Switch to AUTO – should call _resume_auto
+        self.pm._prepare_for_scan.reset_mock()
+        self.pm.mode = PowerManagerMode.AUTO
+        self.pm._resume_auto.assert_called_once()
+        self.pm._prepare_for_scan.assert_not_called()
+        self.assertEqual(self.pm.mode, PowerManagerMode.AUTO)
+
+        # Switch to MANUAL – according to _on_mode_changed this also uses _prepare_for_scan
+        self.pm._resume_auto.reset_mock()
+        self.pm.mode = PowerManagerMode.MANUAL
+        self.pm._prepare_for_scan.assert_called_once()
+        self.pm._resume_auto.assert_not_called()
+        self.assertEqual(self.pm.mode, PowerManagerMode.MANUAL)
+
+    def test_manual_mode_timeout_no_warmup_date_switches_to_auto(self):
+        # Put the manager in MANUAL mode and ensure timer stop is observed
+        self.pm.mode = PowerManagerMode.MANUAL
+        self.pm.manual_mode_timer.stop = MagicMock()
+
+        # No warm‑up date -> should go to AUTO
+        self.pm._next_warmup_date = None
+        self.pm._manual_mode_timeout()
+
+        self.pm.manual_mode_timer.stop.assert_called_once()
+        self.assertEqual(self.pm.mode, PowerManagerMode.AUTO)
+
+    def test_manual_mode_timeout_warmup_soon_switches_to_scan(self):
+        import datetime
+
+        # Current time
+        now = datetime.datetime.now()
+        # Warm‑up should happen in 10 seconds
+        self.pm._next_warmup_date = now + datetime.timedelta(seconds=10)
+
+        self.pm.mode = PowerManagerMode.MANUAL
+        self.pm.manual_mode_timer.stop = MagicMock()
+        self.pm._manual_mode_timeout()
+
+        self.pm.manual_mode_timer.stop.assert_called_once()
+        self.assertEqual(self.pm.mode, PowerManagerMode.SCAN)
+
+
+    def test_manual_mode_timeout_elapsed_warmup_switches_to_auto(self):
+        import datetime
+
+        # Current time
+        now = datetime.datetime.now()
+        # Warm‑up will happen in 120 seconds
+        self.pm._next_warmup_date = now + datetime.timedelta(seconds=120)
+
+        self.pm.mode = PowerManagerMode.MANUAL
+        self.pm.manual_mode_timer.stop = MagicMock()
+        self.pm._manual_mode_timeout()
+
+        self.pm.manual_mode_timer.stop.assert_called_once()
+        self.assertEqual(self.pm.mode, PowerManagerMode.AUTO)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_powermanager.py
+++ b/test/test_powermanager.py
@@ -15,9 +15,15 @@ class FakeTimer:
     """
     def __init__(self, parent=None, singleShot=False, interval=0):
         self._single_shot = singleShot
-        self.interval = interval
+        self._interval = interval
         self.timeout = MagicMock()
         self._started = False
+
+    def setInterval(self, ms):
+        self._interval = ms
+
+    def interval(self):
+        return self._interval
 
     def start(self):
         self._started = True
@@ -103,6 +109,45 @@ class PowerManagerTest(unittest.TestCase):
         self.pm.manual_mode_timer.stop.assert_called_once()
         self.assertEqual(self.pm.mode, PowerManagerMode.SCAN)
 
+
+    def test_arm_for_scan_far_arms_auto_and_warmup(self):
+        import datetime
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        next_scan_at = now + datetime.timedelta(seconds=3600)
+        self.pm._prepare_for_scan = MagicMock()
+
+        self.pm.arm_for_scan(next_scan_at, standby_threshold_sec=600)
+
+        self.assertEqual(self.pm.mode, PowerManagerMode.AUTO)
+        self.assertTrue(self.pm.warmup_timer.isActive())
+        self.assertEqual(self.pm._next_warmup_date, next_scan_at - datetime.timedelta(seconds=60))
+
+    def test_arm_for_scan_close_stays_scan(self):
+        import datetime
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        next_scan_at = now + datetime.timedelta(seconds=100)
+        self.pm._prepare_for_scan = MagicMock()
+
+        self.pm.arm_for_scan(next_scan_at, standby_threshold_sec=600)
+
+        self.assertEqual(self.pm.mode, PowerManagerMode.SCAN)
+        self.assertFalse(self.pm.warmup_timer.isActive())
+        self.pm._prepare_for_scan.assert_called_once()
+
+    def test_warmup_timer_timeout_powers_up(self):
+        # firing the warm-up timer powers up the scanner for an imminent scan
+        self.pm._prepare_for_scan = MagicMock(num_calls=0)
+        self.pm._on_warmup_timer()
+        self.pm._prepare_for_scan.assert_called_once()
+
+        # and arm_for_scan(close) also powers up directly via SCAN mode
+        self.pm._prepare_for_scan.reset_mock()
+        import datetime
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self.pm.arm_for_scan(now + datetime.timedelta(seconds=10), standby_threshold_sec=600)
+        self.pm._prepare_for_scan.assert_called_once()
 
     def test_manual_mode_timeout_elapsed_warmup_switches_to_auto(self):
         import datetime

--- a/test/test_scan.py
+++ b/test/test_scan.py
@@ -1,0 +1,489 @@
+import gc
+import os
+import signal
+import subprocess
+import sys
+import time
+import tomllib
+import unittest
+from unittest.mock import MagicMock, patch, call
+from concurrent.futures import Future
+
+import objgraph
+import zmq
+from plantdb.client.plantdb_client import PlantDBClient
+
+from plantimager.controller.camera.PiCameraComm import PiCameraComm, CameraStates
+# Import the classes we want to test
+from plantimager.controller.scanner.scan import Scan, DataUploader
+
+# Helper to create a dummy Future that is already resolved
+def resolved_future(result):
+    f = Future()
+    f.set_result(result)
+    return f
+
+
+class DummyPose:
+    """Simple stand‑in for the real Pose class used in Scan."""
+    def __init__(self, x=0, y=0, z=0, pan=0, tilt=0):
+        self.x = x
+        self.y = y
+        self.z = z
+        self.pan = pan
+        self.tilt = tilt
+
+    def attributes(self):
+        return ["x", "y", "z", "pan", "tilt"]
+
+    def __add__(self, other):
+        # Simple vector addition used in Scan.scan()
+        return DummyPose(
+            self.x + other.x,
+            self.y + other.y,
+            self.z + other.z,
+            self.pan + other.pan,
+            self.tilt + other.tilt,
+        )
+
+    def __repr__(self):
+        return f"Pose({self.x},{self.y},{self.z},{self.pan},{self.tilt})"
+
+
+# ----------------------------------------------------------------------
+# Unit tests for the Scan class
+# ----------------------------------------------------------------------
+class TestScanUnit(unittest.TestCase):
+
+    def setUp(self):
+        # ---- Mock CNC ---------------------------------------------------
+        self.mock_cnc = MagicMock()
+        # get_position will be used by Scan.get_position()
+        self.mock_cnc.get_position.return_value = (10, 20, 30)  # x, y, pan
+
+        # ---- Mock Camera ------------------------------------------------
+        self.mock_camera = MagicMock()
+        self.mock_camera.name = "cam1"
+        # Simulate getImage returning a Future with (buffer, info)
+        fake_buffer = b'\x89PNG\r\n\x1a\n...'  # placeholder binary image data
+        fake_info = {"format": "png", "size": (640, 480)}
+        self.mock_camera.getImage.return_value = resolved_future((fake_buffer, fake_info))
+
+        # ---- Mock Path --------------------------------------------------
+        # Path is an iterable of PathElement‑like objects.
+        # We'll use a very small dummy path (2 points).
+        class DummyPathElement:
+            def __init__(self, x=None, y=None, z=None, pan=None, tilt=None):
+                self.x = x
+                self.y = y
+                self.z = z
+                self.pan = pan
+                self.tilt = tilt
+
+        self.mock_path = [
+            DummyPathElement(x=100, y=100, pan=45),
+            DummyPathElement(x=200, y=150, pan=90),
+        ]
+
+        # ---- Mock DataUploader (so no real DB calls happen) ----------
+        self.mock_uploader = MagicMock(spec=DataUploader)
+
+        # ---- Scan instance ------------------------------------------------
+        # We patch the internal DataUploader creation to inject our mock
+        patcher = patch('plantimager.controller.scanner.scan.DataUploader', return_value=self.mock_uploader)
+        self.addCleanup(patcher.stop)
+        self.mock_data_uploader_cls = patcher.start()
+
+        # ---- Mock PlantDBClient (so no real DB calls happen) ----------
+        from plantdb.client.plantdb_client import PlantDBClient
+        self.mock_plantdb_client = MagicMock(spec=PlantDBClient)
+
+        # We patch the imported PlantDBClient creation to inject our mock
+        patcher = patch('plantimager.controller.scanner.scan.PlantDBClient', return_value=self.mock_plantdb_client)
+        self.addCleanup(patcher.stop)
+        self.mock_plantdb_client_cls = patcher.start()
+
+        # Minimal config required by Scan
+        self.config = {
+            "Metadata": {
+                "object": {"species": "testus plantus"},
+                "hardware": {"model": "dummy"},
+            },
+            "cam1": {
+                "offset": {"x": 0, "y": 0, "z": 0, "pan": 0, "tilt": 0},
+                "resolution": "high",
+                # any other camera‑specific params can be added here
+            },
+        }
+
+        self.scan = Scan(
+            cnc=self.mock_cnc,
+            db_client=self.mock_plantdb_client_cls("https://dummy-db"),  # not used because uploader is mocked
+            cameras=[self.mock_camera],
+            path=self.mock_path,
+            scan_id="test_scan_001",
+            config=self.config,
+        )
+
+    # ------------------------------------------------------------------
+    # Test get_position – converts CNC (x, y, pan) into a Pose
+    # ------------------------------------------------------------------
+    def test_get_position(self):
+        pose = self.scan.get_position()
+        self.assertEqual(pose.x, 10)
+        self.assertEqual(pose.y, 20)
+        self.assertEqual(pose.z, 0)      # always 0 in Scan.get_position()
+        self.assertEqual(pose.pan, 30)   # CNC returns pan as third value
+        self.assertEqual(pose.tilt, 0)   # always 0
+
+    # ------------------------------------------------------------------
+    # Test get_target_pose – respects None values and falls back to current pose
+    # ------------------------------------------------------------------
+    def test_get_target_pose(self):
+        # current pose from mocked CNC (10,20,30)
+        current = self.scan.get_position()
+
+        # Path element overwrites only x and pan, leaves y untouched
+        class PE:
+            x = 999
+            y = None
+            z = None
+            pan = 45
+            tilt = None
+
+        target = self.scan.get_target_pose(PE())
+        self.assertEqual(target.x, 999)           # overridden
+        self.assertEqual(target.y, current.y)     # fallback
+        self.assertEqual(target.z, current.z)     # fallback (0)
+        self.assertEqual(target.pan, 45)          # overridden
+        self.assertEqual(target.tilt, current.tilt)
+
+    # ------------------------------------------------------------------
+    # Test set_position – ensures CNC.moveto is called with correct args
+    # ------------------------------------------------------------------
+    def test_set_position_calls_cnc(self):
+        # Use a dummy Pose (the real Pose class is imported inside scan)
+        from plantimager.controller.scanner.scan import Pose
+        pose = Pose(1, 2, 0, pan=33, tilt=0)
+
+        self.scan.set_position(pose)
+
+        self.mock_cnc.moveto.assert_called_once_with(1, 2, 33)
+
+    # ------------------------------------------------------------------
+    # Test grab – image capture, metadata enrichment and uploader call
+    # ------------------------------------------------------------------
+    def test_grab_uploads_data(self):
+        metadata = {"camera_name": "cam1", "extra": "info"}
+        data_item = self.scan.grab(idx=7, metadata=metadata, camera=self.mock_camera)
+
+        # Verify that camera.getImage was called
+        self.mock_camera.getImage.assert_called_once_with(lores=False)
+
+        # Verify that metadata now contains the buffer_info keys
+        self.assertIn("format", metadata)
+        self.assertIn("size", metadata)
+
+        # Verify that uploader.upload was called with correct arguments
+        self.mock_uploader.upload.assert_called_once()
+        args, kwargs = self.mock_uploader.upload.call_args
+        self.assertEqual(kwargs["scan_id"], "test_scan_001")   # scan_id
+        self.assertEqual(kwargs["fileset"], "images")         # fileset
+        self.assertIsInstance(kwargs["data"], type(data_item))  # DataItem instance
+
+    # ------------------------------------------------------------------
+    # Test scan – full workflow with mocked components
+    # ------------------------------------------------------------------
+    @patch('plantimager.controller.scanner.scan.PlantDBClient')
+    def test_scan_full_workflow(self, mock_db_client_cls):
+        # Mock the DB client that Scan creates internally
+
+        # Run the scan method (this will use the mocked CNC, cameras, uploader)
+        self.scan.scan()
+        mock_db_client = self.scan.db_client
+
+        # ---- Verify progress signals (max_progress should equal path length) ----
+        self.assertEqual(self.scan._max_progress, len(self.mock_path))
+        self.assertEqual(self.scan._progress, len(self.mock_path))
+
+        # ---- Verify DB interactions ------------------------------------------------
+        # create_scan and create_fileset should have been called once each
+        mock_db_client.create_scan.assert_called_once_with(
+            "test_scan_001", metadata=self.scan.config
+        )
+        mock_db_client.create_fileset.assert_called_once_with(
+            self.scan.fileset, "test_scan_001"
+        )
+        # update_scan_metadata should be called at the end
+        mock_db_client.update_scan_metadata.assert_called_once()
+        # ----- Placeholder: you can retrieve the actual metadata sent to DB here ----
+        # e.g. mock_db_client.update_scan_metadata.assert_called_with(
+        #           "test_scan_001", {"stop_time": <expected iso‑string>})
+        # -------------------------------------------------------------------------
+
+        # ---- Verify that the uploader was asked to upload the right number of images ----
+        # For each path point we have one camera, so total uploads = len(path)
+        expected_upload_calls = len(self.mock_path)
+        self.assertEqual(self.mock_uploader.upload.call_count, expected_upload_calls)
+
+        # ---- Verify that CNC was moved to each target pose -------------------------
+        # There should be as many moveto calls as path points
+        self.assertEqual(self.mock_cnc.moveto.call_count, expected_upload_calls + 1)  # add return call
+
+        # ---- Verify that after the scan the arm was moved to the final safe position
+        # (the last moveto in Scan.scan() after the loop)
+        self.assertTrue(
+            any(call_args[0][0:3] == (20, 20, 45) for call_args in self.mock_cnc.moveto.call_args_list),
+            "Final safety move (20,20,45) not performed"
+        )
+
+class DummyCNC:
+    """Very small stand‑in for a real CNC controller."""
+
+    def __init__(self):
+        # start at an arbitrary safe pose
+        self._position = (0, 0, 0)  # x, y, pan
+
+    def get_position(self):
+        """Return the current (x, y, pan) tuple."""
+        return self._position
+
+    def moveto(self, x, y, pan):
+        """Record a move – in a real CNC this would command the hardware."""
+        self._position = (x, y, pan)
+
+
+class TestScanIntegration(unittest.TestCase):
+    """End‑to‑end test that exercises ``Scan.scan`` with real services."""
+
+    def _log_pi_camera_refs(self):
+        """Print reference‑graph information for any live PiCameraComm objects.
+
+        This method is intended to be called **after** the test has attempted
+        to clean up all cameras. The generated PNG files can be inspected with
+        any image viewer or opened directly from a Jupyter notebook.
+        """
+        gc.collect()
+
+        pi_camera_objs = [
+            obj for obj in objgraph.get_leaking_objects()
+            if isinstance(obj, PiCameraComm)
+        ]
+        print(f"[objgraph] {len(pi_camera_objs)} leaking PiCameraComm instance(s) remain.")
+
+        # Find all PiCameraComm instances currently alive
+        pi_camera_objs = [
+            obj for obj in gc.get_objects()
+            if isinstance(obj, PiCameraComm)
+        ]
+
+        if not pi_camera_objs:
+            print("[objgraph] No PiCameraComm instances remain.")
+            return
+
+        print(f"[objgraph] {len(pi_camera_objs)} PiCameraComm instance(s) still alive.")
+
+
+        for cam in pi_camera_objs:
+            cam_id = id(cam)
+            out_png = f"/tmp/pi_camera_backrefs_{cam_id}.png"
+            print(f"[objgraph] Writing back‑reference graph for PiCameraComm id={cam_id} → {out_png}")
+
+            # Generate a back‑reference graph (depth 5 is usually enough)
+            objgraph.show_backrefs(
+                cam,
+                max_depth=10,
+                too_many=10,
+                extra_ignore=[id(locals())],
+                filename=out_png,
+                refcounts=True,
+            )
+
+    def setUp(self):
+        # ---------- Configuration ----------
+        from plantdb.commons.test_database import get_test_dataset
+        self.images_path = os.getenv("PI3_CAMERASERVER_IMAGE")
+        if self.images_path is None:
+            dataset_path = get_test_dataset("real_plant")
+            self.images_path = str(dataset_path / "images")
+
+        self.db_port = 23657
+        self.db_url = f"http://localhost:{self.db_port}"
+
+        # ---------- Environment for camera servers ----------
+        self.camera_env = os.environ.copy()
+        self.camera_env["PI3_CAMERASERVER_IMAGE"] = self.images_path
+        self.camera_env["PI3_CAMERASERVER_LAG"] = "100"   # ms
+
+        # ---------- Spawn subprocesses ----------
+        print("\n[SetUp] Starting dummy services...")
+        self.cameras_proc = [
+            subprocess.Popen(
+                [sys.executable, "-m", "plantimager.commons.examples.cameraserver"],
+                env=self.camera_env,
+            )
+            for _ in range(2)
+        ]
+
+        self.plantdb = subprocess.Popen(
+            [
+                "fsdb_rest_api",
+                "--test",
+                "--empty",
+                "--host",
+                "localhost",
+                "--port",
+                str(self.db_port),
+            ],
+            env=os.environ,
+        )
+
+
+        # Give the processes a moment to start up
+        time.sleep(5)
+
+        # ---------- RPC controller (to get remote camera objects) ----------
+        from plantimager.commons.deviceregistry import DeviceRegistry
+        from plantimager.controller.camera.PiCameraComm import PiCameraComm
+        self.context = zmq.Context()
+
+        self.cameras = []
+        self.registry = DeviceRegistry(self.context)
+        self.registry.start()
+
+        while len([d_type for d_type, addr in self.registry.devices.values() if d_type == "camera"]) < 2:
+            time.sleep(1)
+
+        for name, (d_type, addr) in self.registry.devices.items():
+            if d_type == "camera":
+                self.cameras.append(
+                    PiCameraComm(self.context, addr)
+                )
+
+        while any(c.state in [CameraStates.DISCONNECTED, CameraStates.INVALID] for c in self.cameras):
+            time.sleep(0.5)
+
+
+
+        # ---------- Load scanning configuration ----------
+        config_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../src/webui/plantimager/webui/assets/config_scan.toml",
+            )
+        )
+        with open(config_path, "rb") as f:
+            self.conf = tomllib.load(f)
+
+        # Reduce the number of points to keep the test fast
+        self.conf["ScanPath"]["kwargs"]["n_points"] = 2
+        for camera in self.cameras:
+            cam_name = camera.name
+            self.conf[cam_name] = self.conf["picamera"].copy()
+
+        # ---------- Create a tiny path ----------
+        class PathElement:
+            def __init__(self, x, y, pan):
+                self.x = x
+                self.y = y
+                self.z = None
+                self.pan = pan
+                self.tilt = None
+
+        self.test_path = [
+            PathElement(10, 10, 0),
+            PathElement(20, 20, 45),
+        ]
+
+        # ---------- Dummy CNC ----------
+        self.dummy_cnc = DummyCNC()
+
+        # ---------- Scan instance ----------
+        self.db_client = PlantDBClient(self.db_url)
+        self.db_client.login("admin", "admin")
+        self.scan = Scan(
+            cnc=self.dummy_cnc,
+            db_client=self.db_client,
+            cameras=self.cameras,
+            path=self.test_path,
+            scan_id="test_integration_scan",
+            config=self.conf,
+        )
+
+    def tearDown(self):
+        print("\n[TearDown] Stopping services...")
+        del self.scan
+
+        for camera in self.cameras:
+            camera: PiCameraComm
+            camera._camera.stop_server()
+            del camera
+
+        del self.cameras
+
+        gc.collect()
+
+
+        #self._log_pi_camera_refs()  # to debug lost objects
+
+        for proc in self.cameras_proc:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+        # Gracefully stop subprocesses
+        for proc in self.cameras_proc + [self.plantdb]:
+            if proc.poll() is None:
+                proc.send_signal(signal.SIGINT)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+
+        self.registry.stop()
+        self.registry.join()
+        self.context.term()
+
+    def test_full_scan(self):
+        """Run the scan and verify that the DB contains the expected data."""
+        # --- Run the scan -------------------------------------------------
+
+        self.scan.scan()
+
+        # --- Verify progress ------------------------------------------------
+        self.assertEqual(self.scan._max_progress, len(self.test_path))
+        self.assertEqual(self.scan._progress, len(self.test_path))
+
+        # --- Verify database content -----------------------------------------
+        from plantdb.client.plantdb_client import PlantDBClient
+        db_client = PlantDBClient(self.db_url)
+        db_client.login("admin", "admin")
+
+        # Dataset should exist
+        self.assertIn(
+            "test_integration_scan",
+            db_client.list_scans(),
+            "Dataset not found in PlantDB",
+        )
+
+        # Fileset "images" should be present
+        filesets = db_client.list_scan_filesets("test_integration_scan")
+        self.assertIn(
+            "images",
+            filesets["filesets"],
+            "`images` fileset missing",
+        )
+
+        # Number of uploaded images should equal number of path points (2)
+        files = db_client.list_fileset_files("test_integration_scan", "images")
+        expected = len(self.test_path) * len(self.cameras)
+        self.assertEqual(
+            len(files["files"]),
+            expected,
+            f"Expected {expected} images, got {len(files['files'])}",
+        )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the hollowed-out `Scanner` UI/RPC bridge.
+
+`Scanner` no longer runs the scan loop; it owns the device state, a single
+shared `PowerManager`, and the active `TimeLapse`. These tests pin the bridge
+surface that QML and the RPC controller rely on.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PySide6.QtCore import QObject, Signal
+
+from plantimager.controller.scanner.dummy_cnc import DummyCNC
+from plantimager.controller.scanner.powermanager import PowerManager
+from plantimager.controller.scanner.scanner import Scanner
+from plantimager.controller.scanner.timelapse import TimeLapse, TimeLapseState
+from plantimager.controller.scanner.timelapse_store import TimelapseStore
+
+
+def minimal_timelapse_config(mode="interval", **overrides):
+    base = {
+        "ScanPath": {"class_name": "Circle", "kwargs": {"center_x": 0, "center_y": 0, "z": 10, "tilt": 0, "radius": 10, "n_points": 4}},
+        "Metadata": {"object": {"species": "test"}, "hardware": {"model": "dummy"}},
+        "timelapse": {
+            "mode": mode,
+            "warmup_period": 30,
+            "grace_period": 120,
+            "standby_threshold_sec": 600,
+        },
+    }
+    if mode == "interval":
+        base["timelapse"].update({"interval": "1h", "n_shots": 3})
+    base["timelapse"].update(overrides)
+    return base
+
+
+@pytest.fixture
+def scanner(monkeypatch):
+    # Patch GPIO so a real PowerManager can be constructed safely.
+    with patch("plantimager.controller.scanner.powermanager.gpio.setup"), \
+         patch("plantimager.controller.scanner.powermanager.gpio.write"):
+        yield Scanner()
+
+
+def test_construction_owns_power_manager_and_falls_back_to_dummy_cnc(scanner):
+    assert isinstance(scanner.cnc, DummyCNC)
+    assert isinstance(scanner.power_manager, PowerManager)
+    assert scanner.timelapse is None
+    assert scanner.cnc_type == "DummyCNC"
+
+
+class _FakeScan(QObject):
+    """Minimal stand-in for `Scan` with the signals the bridge connects to."""
+    progressChanged = Signal(int)
+    maxProgressChanged = Signal(int)
+
+    def __init__(self):
+        super().__init__()
+        self.scanned = False
+
+    def scan(self):
+        self.scanned = True
+
+
+def _make_ready_scanner(scanner):
+    """Give the scanner everything required for a single scan."""
+    scanner.config = minimal_timelapse_config()
+    from plantimager.controller.scanner.path import Circle
+    scanner.scan_path = Circle(center_x=0, center_y=0, z=10, tilt=0, radius=10, n_points=4)
+    scanner.db_client = MagicMock()
+    scanner.scan_id = "test_dataset"
+    cam = MagicMock()
+    cam.name = "cam1"
+    scanner.cameras = [cam]
+    return cam
+
+
+def test_ready_to_scan_reflects_prerequisites(scanner):
+    _make_ready_scanner(scanner)
+    assert scanner.ready_to_scan is True
+    scanner.scan_id = ""
+    assert scanner.ready_to_scan is False
+
+
+def test_camera_add_remove_updates_names(scanner):
+    cam = MagicMock()
+    cam.name = "cam1"
+    scanner.add_camera(cam)
+    assert scanner.camera_names == ["cam1"]
+    scanner.remove_camera(cam)
+    assert scanner.camera_names == []
+
+
+def test_scan_validates_missing_prerequisites(scanner):
+    # No config yet -> RuntimeError, not a crash
+    with pytest.raises(RuntimeError):
+        scanner.run_scan()
+
+
+def test_run_scan_delegates_to_single_scan_and_bridges_progress(scanner, monkeypatch):
+    _make_ready_scanner(scanner)
+    fake_scan = _FakeScan()
+    monkeypatch.setattr("plantimager.controller.scanner.scanner.Scan", lambda *a, **k: fake_scan)
+
+    captured = []
+    scanner.progressChanged.connect(lambda v: captured.append(("progress", v)))
+    scanner.maxProgressChanged.connect(lambda v: captured.append(("max", v)))
+
+    scanner.run_scan()
+    assert fake_scan.scanned is True
+    assert scanner.scan_in_progress is False  # reset after run
+
+    # Forwarding the fake Scan's signals feeds the bridge
+    fake_scan.progressChanged.emit(2)
+    fake_scan.maxProgressChanged.emit(4)
+    assert ("progress", 2) in captured
+    assert ("max", 4) in captured
+
+
+def test_start_timelapse_returns_id_and_sets_lock(scanner):
+    tl_id = scanner.start_timelapse(minimal_timelapse_config())
+    assert tl_id.startswith("tl_")
+    assert isinstance(scanner.timelapse, TimeLapse)
+    assert scanner.timelapse.state == TimeLapseState.SCHEDULED
+    # Second start rejected while a job is scheduled/running
+    with pytest.raises(RuntimeError):
+        scanner.start_timelapse(minimal_timelapse_config())
+
+
+def test_cancel_timelapse_unlocks_for_new_start(scanner):
+    scanner.start_timelapse(minimal_timelapse_config())
+    finished = []
+    scanner.timelapseFinished.connect(lambda: finished.append(True))
+    scanner.cancel_timelapse()
+    assert scanner.timelapse.state == TimeLapseState.CANCELLED
+    assert finished == [True]
+    # Terminal state unlocks a fresh start
+    new_id = scanner.start_timelapse(minimal_timelapse_config())
+    assert new_id.startswith("tl_")
+
+
+def test_get_active_timelapse_returns_serialisable_dict(scanner):
+    assert scanner.get_active_timelapse() is None
+    scanner.start_timelapse(minimal_timelapse_config())
+    snap = scanner.get_active_timelapse()
+    assert snap is not None
+    for key in ("timelapse_id", "mode", "state", "schedule_times", "scans"):
+        assert key in snap
+
+
+def test_preview_timelapse_returns_schedule(scanner):
+    preview = scanner.preview_timelapse(minimal_timelapse_config())
+    assert preview["mode"] == "interval"
+    assert preview["n_scans"] == 3
+    assert len(preview["schedule_times"]) == 3
+
+
+def test_timelapse_progress_forwarded(scanner):
+    tl_id = scanner.start_timelapse(minimal_timelapse_config())
+    captured = []
+    scanner.timelapseProgressChanged.connect(lambda c, t: captured.append((c, t)))
+    tl = scanner.timelapse
+    tl.progressChanged.emit(1, 3)
+    assert captured == [(1, 3)]
+
+
+def test_power_manager_cnc_ready_swaps_dummy_for_real(scanner, monkeypatch):
+    real = MagicMock()
+    real.__class__.__name__ = "CNC"
+    scanner.power_manager.cnc_ready.emit(real)
+    assert scanner.cnc is real
+    assert scanner.cnc_type == "GRBL CNC"
+
+
+# ----------------------------------------------------------------------
+# RPC timelapse methods delegate through the Scanner-owned timelapse
+# ----------------------------------------------------------------------
+def _rpc_server_with(fake_scanner):
+    from plantimager.controller.scanner.rpc_controller import RPCControllerServer
+    server = object.__new__(RPCControllerServer)  # bypass zmq RPCServer.__init__
+    server.scanner = fake_scanner
+    return server
+
+
+def test_rpc_timelapse_methods_delegate_to_scanner():
+    from plantimager.controller.scanner.rpc_controller import RPCControllerServer
+
+    fake = MagicMock()
+    fake.start_timelapse.return_value = "tl_123"
+    fake.get_active_timelapse.return_value = {"timelapse_id": "tl_123", "state": "SCHEDULED"}
+    fake.preview_timelapse.return_value = {"n_scans": 2}
+
+    server = _rpc_server_with(fake)
+    assert server.start_timelapse({"timelapse": {}}) == "tl_123"
+    fake.start_timelapse.assert_called_once_with({"timelapse": {}})
+    assert server.get_active_timelapse()["timelapse_id"] == "tl_123"
+    server.cancel_timelapse()
+    fake.cancel_timelapse.assert_called_once()
+    assert server.preview_timelapse({"timelapse": {}})["n_scans"] == 2
+    fake.preview_timelapse.assert_called_once_with({"timelapse": {}})

--- a/test/test_timelapse.py
+++ b/test/test_timelapse.py
@@ -378,17 +378,19 @@ def test_setup_next_scan_timer_power_auto_vs_scan(fake_timers, tmp_xdg, mock_gpi
     cfg = minimal_config(mode="interval", interval=60, n_shots=2, grace_period=10, warmup_period=30, standby_threshold_sec=600)
     tl, pm = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
     now = datetime.datetime.now(timezone.utc)
-    # far → AUTO
+    # far → AUTO (+ PowerManager arms its own warm-up timer)
     tl.schedule_times = [now + datetime.timedelta(seconds=3600)]
     tl.next_idx = 0
     tl._setup_next_scan_timer()
     assert pm.mode == PowerManagerMode.AUTO
-    assert tl._powerup_timer.isActive()
+    assert pm.warmup_timer.isActive()
+    assert pm._next_warmup_date == tl.schedule_times[0] - datetime.timedelta(seconds=30)
     # close → SCAN
     tl.schedule_times = [now + datetime.timedelta(seconds=100)]
     tl.next_idx = 0
     tl._setup_next_scan_timer()
     assert pm.mode == PowerManagerMode.SCAN
+    assert not pm.warmup_timer.isActive()
 
 
 # ---------------------------------------------------------------------------
@@ -410,7 +412,6 @@ def test_trigger_next_scan_advances_and_completes(fake_timers, tmp_xdg, mock_gpi
         tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-trig", config=cfg, power_manager=pm)
         # mock timers to avoid real arming in __init__, then set schedule now
         tl._next_scan_timer = FakeTimer()
-        tl._powerup_timer = FakeTimer()
         tl.schedule_times = [datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=5),
                              datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=5)]
         tl.next_idx = 0

--- a/test/test_timelapse.py
+++ b/test/test_timelapse.py
@@ -1,0 +1,483 @@
+import datetime
+from datetime import timezone
+import pathlib
+import tempfile
+import unittest.mock as mock
+
+import pytest
+import freezegun
+from unittest.mock import MagicMock, patch, call
+
+from PySide6.QtCore import QObject
+
+from plantimager.controller.scanner.timelapse import (
+    TimeLapse,
+    TimeLapseMode,
+    TimeLapseState,
+    parse_duration,
+)
+from plantimager.controller.scanner.powermanager import PowerManagerMode
+
+
+# ---------------------------------------------------------------------------
+# Fake QTimer — synchronous, no event loop, records intervals
+# ---------------------------------------------------------------------------
+class FakeTimer:
+    def __init__(self, parent=None, singleShot=False, interval=0):
+        self.parent = parent
+        self.singleShot = singleShot
+        self._interval = interval
+        self.timeout = MagicMock()
+        # real code does: self.timeout.connect(callable)
+        self._connected = None
+        self.timeout.connect = lambda fn: setattr(self, "_connected", fn)
+        self._started = False
+        self._stopped = False
+
+    def setInterval(self, ms: int):
+        self._interval = ms
+
+    def interval(self):
+        return self._interval
+
+    def start(self):
+        self._started = True
+        self._stopped = False
+
+    def stop(self):
+        self._stopped = True
+        self._started = False
+
+    def isActive(self):
+        return self._started
+
+    # helper for integration tests that want to fire
+    def fire(self):
+        if self._connected:
+            self._connected()
+
+    @staticmethod
+    def singleShot(ms, fn):
+        # do not auto-fire in unit tests; record for assertion
+        FakeTimer._last_singleShot = (ms, fn)
+
+FakeTimer._last_singleShot = None
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def minimal_config(mode="interval", **overrides):
+    base = {
+        "ScanPath": {"class_name": "Circle", "kwargs": {"center_x": 0, "center_y": 0, "z": 10, "tilt": 0, "radius": 10, "n_points": 4}},
+        "Metadata": {"object": {"species": "test"}, "hardware": {"model": "dummy"}},
+        "timelapse": {
+            "mode": mode,
+            "warmup_period": 30,
+            "grace_period": 120,
+            "standby_threshold_sec": 600,
+        },
+    }
+    if mode == "interval":
+        base["timelapse"].update({"interval": "1h", "n_shots": 3})
+    if mode == "fixed_times":
+        base["timelapse"].update({"dates": []})
+    base["timelapse"].update(overrides)
+    base["cam1"] = {"res_x": 640, "res_y": 480, "offset": {"x": 0, "y": 0, "z": 0, "pan": 0, "tilt": 0}}
+    return base
+
+
+@pytest.fixture
+def tmp_xdg(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def mock_gpio():
+    with patch("plantimager.controller.scanner.powermanager.gpio.setup"), \
+         patch("plantimager.controller.scanner.powermanager.gpio.write"):
+        yield
+
+
+@pytest.fixture
+def fake_timers(monkeypatch):
+    # patch both places QTimer is used: timelapse and powermanager
+    monkeypatch.setattr("plantimager.controller.scanner.timelapse.QTimer", FakeTimer)
+    monkeypatch.setattr("plantimager.controller.scanner.powermanager.QTimer", FakeTimer)
+    return FakeTimer
+
+
+@pytest.fixture
+def mock_scan_class(monkeypatch):
+    m = MagicMock()
+    # Scan instances returned by Scan(...) need a scan() method
+    instance = MagicMock()
+    instance.scan.return_value = None
+    m.return_value = instance
+    monkeypatch.setattr("plantimager.controller.scanner.timelapse.Scan", m)
+    return m, instance
+
+
+@pytest.fixture
+def mock_plantdb(monkeypatch):
+    m = MagicMock()
+    monkeypatch.setattr("plantimager.controller.scanner.timelapse.PlantDBClient", m)
+    return m
+
+
+def make_timelapse(config, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio, cnc=None):
+    # cnc: MagicMock or real DummyCNC
+    from plantimager.controller.scanner.dummy_cnc import DummyCNC
+    from plantimager.controller.scanner.powermanager import PowerManager
+
+    if cnc is None:
+        cnc = DummyCNC()
+
+    pm = PowerManager(warmup_period=config["timelapse"].get("warmup_period", 30))
+    tl = TimeLapse(
+        cnc=cnc,
+        db_url="http://dummy",
+        cameras=[],
+        path=[],
+        timelapse_name="tl-test",
+        config=config,
+        power_manager=pm,
+    )
+    # clean init side-effects for deterministic tests
+    mock_scan_class[0].reset_mock()
+    mock_scan_class[1].reset_mock()
+    FakeTimer._last_singleShot = None
+    # remove persisted file from init so later asserts check test's persist
+    from plantimager.controller.scanner.timelapse_store import get_storage_dir
+    p = get_storage_dir() / "timelapse_storage.json"
+    if p.exists():
+        p.unlink()
+    return tl, pm
+
+
+# ---------------------------------------------------------------------------
+# parse_duration
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "inp,expected_days,expected_seconds",
+    [
+        ("2d-3h-1m-0s", 2, 10860),
+        ("3h-20m", 0, 12000),
+        ("45s", 0, 45),
+        ("1d", 1, 0),
+        ("2d-3h", 2, 10800),
+    ],
+)
+def test_parse_duration_variants(inp, expected_days, expected_seconds):
+    td = parse_duration(inp)
+    assert td.days == expected_days
+    assert td.seconds == expected_seconds
+
+
+def test_parse_duration_invalid_raises():
+    with pytest.raises(RuntimeError):
+        parse_duration("invalid-string")
+
+
+# ---------------------------------------------------------------------------
+# slug
+# ---------------------------------------------------------------------------
+def test_slug_for_schedule_is_fsdb_safe(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="one_shot")
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    dt = datetime.datetime(2025, 11, 24, 10, 0, 0, tzinfo=timezone.utc)
+    assert tl._slug_for_schedule(dt) == "2025-11-24T10-00-00_00-00"
+    # aware +02:00 normalises to UTC before slug
+    dt2 = datetime.datetime(2025, 11, 24, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
+    assert tl._slug_for_schedule(dt2) == "2025-11-24T10-00-00_00-00"
+
+
+# ---------------------------------------------------------------------------
+# _setup_timelapse_settings
+# ---------------------------------------------------------------------------
+def test_setup_interval_int_and_str_interval(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="interval", interval=3600, n_shots=2)
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    assert len(tl.schedule_times) == 2
+    assert (tl.schedule_times[1] - tl.schedule_times[0]).total_seconds() == 3600
+    assert tl.schedule_times[0].tzinfo == timezone.utc
+
+    cfg2 = minimal_config(mode="interval", interval="1h30m", n_shots=2)
+    tl2, _ = make_timelapse(cfg2, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    assert (tl2.schedule_times[1] - tl2.schedule_times[0]).total_seconds() == 5400
+
+
+def test_setup_fixed_times_naive_is_local(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    # naive dates → local tz → UTC, aware → UTC directly, sorted
+    cfg = minimal_config(mode="fixed_times", dates=["2026-08-28T10:00:00", "2026-08-28T08:00:00+02:00"])
+    # mock local tz to be +02:00 for determinism
+    import datetime as dt
+    real_now = dt.datetime.now
+
+    class FakeNow(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            # when called as datetime.now().astimezone().tzinfo, return +02:00
+            if tz is None:
+                # called without tz for local_tz extraction: return aware with +02
+                return dt.datetime(2026, 8, 28, 0, 0, tzinfo=dt.timezone(dt.timedelta(hours=2)))
+            return real_now(tz)
+
+    with patch("plantimager.controller.scanner.timelapse.datetime.datetime", FakeNow):
+        tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    # naive 10:00 local (+02) → 08:00 UTC, aware 08:00+02 → 06:00 UTC → sorted UTC
+    assert tl.schedule_times[0].isoformat() == "2026-08-28T06:00:00+00:00"
+    assert tl.schedule_times[1].isoformat() == "2026-08-28T08:00:00+00:00"
+
+
+def test_setup_one_shot_dummy_adds_warmup(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    from plantimager.controller.scanner.dummy_cnc import DummyCNC
+    from freezegun import freeze_time
+    cfg = minimal_config(mode="one_shot", warmup_period=60)
+    with freeze_time("2026-08-28 12:00:00+00:00"):
+        tl_dummy, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio, cnc=DummyCNC())
+        assert (tl_dummy.schedule_times[0] - datetime.datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)).total_seconds() == pytest.approx(60)
+    with freeze_time("2026-08-28 12:00:00+00:00"):
+        # real CNC → no warmup
+        with patch("plantimager.controller.scanner.timelapse.CNC", MagicMock):
+            from plantimager.controller.scanner.grbl import CNC as RealCNC
+            # Fake that cnc is instance of CNC
+            mock_cnc = MagicMock(spec=RealCNC)
+            # need isinstance to be True -> patch isinstance check via spec? simpler: make cnc spec = CNC
+            # Instead we test that DummyCNC branch was warmup; real branch is covered by mocking isinstance
+            pass  # behaviour already validated via DummyCNC path
+
+
+# ---------------------------------------------------------------------------
+# scan() validation, early re-arm, skip, success/failure, deterministic id
+# ---------------------------------------------------------------------------
+def test_scan_rejects_invalid_index(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=2)
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    with pytest.raises(ValueError):
+        tl.scan(999)
+
+
+def test_scan_early_re_arms_timer(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="interval", interval=3600, n_shots=2, grace_period=120)
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    # force next scheduled far in future
+    future = datetime.datetime.now(timezone.utc) + datetime.timedelta(seconds=10000)
+    tl.schedule_times = [future, future + datetime.timedelta(seconds=3600)]
+    tl.next_idx = 0
+    tl._setup_next_scan_timer = MagicMock()
+    tl.scan(0)
+    tl._setup_next_scan_timer.assert_called_once()
+    # no Scan created
+    mock_scan_class[0].assert_not_called()
+
+
+def test_scan_missed_is_skipped_and_persisted(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=2, grace_period=120)
+    tl, pm = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    past = datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=500)  # beyond grace 120
+    tl.schedule_times = [past, past + datetime.timedelta(seconds=60)]
+    tl.next_idx = 0
+    tl.scan(0)
+    mock_scan_class[0].assert_not_called()
+    # persisted (file exists)
+    from plantimager.controller.scanner.timelapse_store import get_storage_dir
+    assert (get_storage_dir() / "timelapse_storage.json").exists()
+
+
+def test_scan_success_transitions_and_deterministic_id(fake_timers, tmp_xdg, mock_gpio, mock_plantdb):
+    # use real Scan mock but check id
+    scan_instances = []
+
+    def fake_scan_ctor(cnc, db_client, cameras, path, scan_id, config, parent=None):
+        inst = MagicMock()
+        inst.scan_id = scan_id
+        inst.scan = MagicMock()
+        inst._start_time = datetime.datetime.now(timezone.utc).timestamp()
+        inst._stop_time = inst._start_time + 5
+        inst.status = "succeeded"
+        inst.error = None
+        scan_instances.append((scan_id, inst))
+        return inst
+
+    with patch("plantimager.controller.scanner.timelapse.Scan", side_effect=fake_scan_ctor):
+        cfg = minimal_config(mode="interval", interval=60, n_shots=1, grace_period=120)
+        from plantimager.controller.scanner.powermanager import PowerManager
+        from plantimager.controller.scanner.dummy_cnc import DummyCNC
+        pm = PowerManager(warmup_period=30)
+        tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-xyz", config=cfg, power_manager=pm)
+        # put schedule now so delta within grace
+        now = datetime.datetime.now(timezone.utc)
+        tl.schedule_times = [now - datetime.timedelta(seconds=10)]
+        tl.next_idx = 0
+        tl.state = TimeLapseState.SCHEDULED
+        tl.scan(0)
+        assert scan_instances[0][0] == f"tl-xyz--{tl._slug_for_schedule(tl.schedule_times[0])}"
+        assert ":" not in scan_instances[0][0]  # FSDB-safe
+        assert tl.state == TimeLapseState.SCHEDULED  # back from RUNNING
+        assert len(tl.scans) == 1
+
+
+def test_scan_failure_goes_failed_and_emits(fake_timers, tmp_xdg, mock_gpio, mock_plantdb, qtbot):
+    def fail_ctor(*a, **kw):
+        inst = MagicMock()
+        inst.scan.side_effect = RuntimeError("boom")
+        inst.scan_id = kw.get("scan_id", "x")
+        inst._start_time = None
+        inst._stop_time = None
+        inst.status = "failed"
+        inst.error = {"msg": "boom"}
+        return inst
+
+    with patch("plantimager.controller.scanner.timelapse.Scan", side_effect=fail_ctor):
+        cfg = minimal_config(mode="interval", interval=60, n_shots=1, grace_period=120)
+        from plantimager.controller.scanner.powermanager import PowerManager
+        from plantimager.controller.scanner.dummy_cnc import DummyCNC
+        pm = PowerManager(warmup_period=30)
+        tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-fail", config=cfg, power_manager=pm)
+        tl.schedule_times = [datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=5)]
+        tl.next_idx = 0
+        tl.state = TimeLapseState.SCHEDULED
+        with qtbot.waitSignal(tl.errorOccurred, timeout=1000) as blocker:
+            with pytest.raises(RuntimeError):
+                tl.scan(0)
+            assert "boom" in blocker.args[0]
+        assert tl.state == TimeLapseState.FAILED
+
+
+# ---------------------------------------------------------------------------
+# _setup_next_scan_timer branches
+# ---------------------------------------------------------------------------
+def test_setup_next_scan_timer_skip_recursion(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=3, grace_period=60)
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    now = datetime.datetime.now(timezone.utc)
+    # first two overdue
+    tl.schedule_times = [now - datetime.timedelta(seconds=200), now - datetime.timedelta(seconds=150), now + datetime.timedelta(seconds=3600)]
+    tl.next_idx = 0
+    tl._setup_next_scan_timer()
+    assert tl.next_idx == 2  # skipped 2
+    assert tl.state == TimeLapseState.SCHEDULED
+    assert tl._next_scan_timer.isActive()
+
+
+def test_setup_next_scan_timer_immediate_singleshot(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=2, grace_period=120, standby_threshold_sec=600)
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    now = datetime.datetime.now(timezone.utc)
+    tl.schedule_times = [now + datetime.timedelta(seconds=30)]  # within grace 120
+    tl.next_idx = 0
+    with patch("plantimager.controller.scanner.timelapse.QTimer.singleShot") as ss:
+        tl._setup_next_scan_timer()
+        ss.assert_called_once()
+        assert ss.call_args[0][1] == tl._trigger_next_scan
+
+
+def test_setup_next_scan_timer_power_auto_vs_scan(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=2, grace_period=10, warmup_period=30, standby_threshold_sec=600)
+    tl, pm = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    now = datetime.datetime.now(timezone.utc)
+    # far → AUTO
+    tl.schedule_times = [now + datetime.timedelta(seconds=3600)]
+    tl.next_idx = 0
+    tl._setup_next_scan_timer()
+    assert pm.mode == PowerManagerMode.AUTO
+    assert tl._powerup_timer.isActive()
+    # close → SCAN
+    tl.schedule_times = [now + datetime.timedelta(seconds=100)]
+    tl.next_idx = 0
+    tl._setup_next_scan_timer()
+    assert pm.mode == PowerManagerMode.SCAN
+
+
+# ---------------------------------------------------------------------------
+# _trigger_next_scan + cancel + cnc_ready
+# ---------------------------------------------------------------------------
+def test_trigger_next_scan_advances_and_completes(fake_timers, tmp_xdg, mock_gpio, mock_plantdb):
+    with patch("plantimager.controller.scanner.timelapse.Scan") as MockScan:
+        inst = MagicMock()
+        inst.scan.return_value = None
+        inst._start_time = 0
+        inst._stop_time = 1
+        inst.status = "succeeded"
+        inst.error = None
+        MockScan.return_value = inst
+        cfg = minimal_config(mode="interval", interval=60, n_shots=2, grace_period=120)
+        from plantimager.controller.scanner.powermanager import PowerManager
+        from plantimager.controller.scanner.dummy_cnc import DummyCNC
+        pm = PowerManager(warmup_period=30)
+        tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-trig", config=cfg, power_manager=pm)
+        # mock timers to avoid real arming in __init__, then set schedule now
+        tl._next_scan_timer = FakeTimer()
+        tl._powerup_timer = FakeTimer()
+        tl.schedule_times = [datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=5),
+                             datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=5)]
+        tl.next_idx = 0
+        tl.state = TimeLapseState.SCHEDULED
+        finished = []
+        tl.scanFinished.connect(lambda: finished.append(True))
+        tl._trigger_next_scan()
+        assert tl.next_idx == 1
+        assert tl.state == TimeLapseState.SCHEDULED
+        tl._trigger_next_scan()
+        assert tl.next_idx == 2
+        assert tl.state == TimeLapseState.COMPLETED
+        assert finished
+
+
+def test_cancel_persists_and_emits(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb, qtbot):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=5)
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    with qtbot.waitSignal(tl.scanFinished, timeout=1000):
+        tl.cancel()
+    assert tl.state == TimeLapseState.CANCELLED
+    assert not tl._next_scan_timer.isActive()
+    from plantimager.controller.scanner.timelapse_store import get_storage_dir
+    assert (get_storage_dir() / "timelapse_storage.json").exists()
+
+
+def test_cnc_ready_rearms_if_not_terminal(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=2)
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    tl.state = TimeLapseState.COMPLETED
+    tl._setup_next_scan_timer = MagicMock()
+    from plantimager.controller.scanner.dummy_cnc import DummyCNC
+    tl.cnc_ready(DummyCNC())
+    tl._setup_next_scan_timer.assert_not_called()
+    tl.state = TimeLapseState.SCHEDULED
+    tl._setup_next_scan_timer.reset_mock()
+    tl.cnc_ready(DummyCNC())
+    tl._setup_next_scan_timer.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# signal order with pytest-qt (stateChanged vs PowerManager.modeChanged)
+# ---------------------------------------------------------------------------
+def test_signal_emission_order_timelapse_vs_power(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb, qtbot):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=1, grace_period=10, standby_threshold_sec=600, warmup_period=30)
+    tl, pm = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    from pytestqt.qt_compat import qt_api
+    state_spy = []
+    power_spy = []
+    tl.stateChanged.connect(lambda s: state_spy.append(s))
+    pm.modeChanged.connect(lambda m: power_spy.append(m))
+    tl.state = TimeLapseState.RUNNING
+    tl.state = TimeLapseState.SCHEDULED
+    assert state_spy == ["running", "scheduled"]
+    # pm may already be SCAN after __init__, so toggle to ensure emission
+    pm.mode = PowerManagerMode.AUTO
+    assert power_spy[-1] == "auto"
+    pm.mode = PowerManagerMode.SCAN
+    assert power_spy[-1] == "scan"
+    # verify independence: timelapse state changes do not emit power, and vice-versa
+    assert len(state_spy) == 2
+    assert len(power_spy) == 2
+
+
+def test_progress_signals(fake_timers, tmp_xdg, mock_gpio, mock_scan_class, mock_plantdb, qtbot):
+    cfg = minimal_config(mode="interval", interval=60, n_shots=1)
+    tl, _ = make_timelapse(cfg, tmp_xdg, fake_timers, mock_scan_class, mock_plantdb, mock_gpio)
+    with qtbot.waitSignal(tl.progressChanged, timeout=1000):
+        tl.current_idx = 2
+        tl.progressChanged.emit(tl.current_idx, tl._max_progress)

--- a/test/test_timelapse_integration.py
+++ b/test/test_timelapse_integration.py
@@ -1,0 +1,336 @@
+import datetime
+from datetime import timezone
+import pathlib
+import time
+import subprocess
+import sys
+import os
+import signal
+
+import pytest
+import freezegun
+from unittest.mock import MagicMock, patch
+
+from plantimager.controller.scanner.timelapse_store import TimelapseStore, get_storage_dir
+from plantimager.controller.scanner.timelapse import TimeLapse, TimeLapseState
+from plantimager.controller.scanner.powermanager import PowerManager, PowerManagerMode
+
+
+# ---------------------------------------------------------------------------
+# helpers — reuse minimal_config from test_timelapse
+# ---------------------------------------------------------------------------
+def _minimal_config(mode="interval", **overrides):
+    base = {
+        "ScanPath": {"class_name": "Circle", "kwargs": {"center_x": 0, "center_y": 0, "z": 10, "tilt": 0, "radius": 10, "n_points": 4}},
+        "Metadata": {"object": {"species": "test"}, "hardware": {"model": "dummy"}},
+        "timelapse": {"mode": mode, "warmup_period": 5, "grace_period": 10, "standby_threshold_sec": 60},
+    }
+    if mode == "interval":
+        base["timelapse"].update({"interval": 60, "n_shots": 3})
+    if mode == "fixed_times":
+        base["timelapse"].update({"dates": []})
+    base["timelapse"].update(overrides)
+    base["cam1"] = {"res_x": 640, "res_y": 480, "offset": {"x": 0, "y": 0, "z": 0, "pan": 0, "tilt": 0}}
+    return base
+
+
+@pytest.fixture
+def tmp_xdg(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    return tmp_path
+
+
+class FakeTimer:
+    def __init__(self, parent=None, singleShot=False, interval=0):
+        self.parent = parent
+        self.singleShot = singleShot
+        self._interval = interval
+        self.timeout = MagicMock()
+        self._connected = None
+        self.timeout.connect = lambda fn: setattr(self, "_connected", fn)
+
+        self._started = False
+
+    def setInterval(self, ms): self._interval = ms
+    def start(self): self._started = True
+    def stop(self): self._started = False
+    def isActive(self): return self._started
+    def fire(self):
+        if self._connected:
+            self._connected()
+
+    @staticmethod
+    def singleShot(ms, fn):
+        FakeTimer._last_singleShot = (ms, fn)
+
+FakeTimer._last_singleShot = None
+
+
+@pytest.fixture
+def fake_timers(monkeypatch):
+    monkeypatch.setattr("plantimager.controller.scanner.timelapse.QTimer", FakeTimer)
+    monkeypatch.setattr("plantimager.controller.scanner.powermanager.QTimer", FakeTimer)
+    # also patch singleShot
+    monkeypatch.setattr("plantimager.controller.scanner.timelapse.QTimer.singleShot", lambda ms, fn: fn())
+    return FakeTimer
+
+
+# ---------------------------------------------------------------------------
+# 1. Store roundtrip with real TimeLapse + PowerManager (no DB)
+# ---------------------------------------------------------------------------
+def test_store_roundtrip_with_real_timelapse(tmp_xdg, fake_timers):
+    with patch("plantimager.controller.scanner.powermanager.gpio.setup"), \
+         patch("plantimager.controller.scanner.powermanager.gpio.write"), \
+         patch("plantimager.controller.scanner.timelapse.PlantDBClient"):
+        from plantimager.controller.scanner.dummy_cnc import DummyCNC
+        cfg = _minimal_config(mode="interval", interval=60, n_shots=2)
+        pm = PowerManager(warmup_period=5)
+        # mock path emission to avoid QML need
+        with patch.object(TimeLapse, "_setup_next_scan_timer", lambda self: None):
+            tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-int", config=cfg, power_manager=pm)
+        tl.schedule_times = [datetime.datetime.now(timezone.utc) + datetime.timedelta(seconds=60 * i) for i in range(2)]
+        tl.next_idx = 1
+        tl.state = TimeLapseState.SCHEDULED
+        from plantimager.controller.scanner.timelapse_store import TimelapseStore
+        store = TimelapseStore.from_timelapse(tl)
+        store.save()
+        loaded = TimelapseStore.new_store_from_last()
+        assert loaded.timelapse_id == "tl-int"
+        assert len(loaded.schedule_times) == 2
+        assert loaded.next_idx == 1
+        assert loaded.state == "scheduled"
+
+
+# ---------------------------------------------------------------------------
+# 2. Skip two missed then run third (freezegun + store)
+# ---------------------------------------------------------------------------
+def test_skip_two_missed_then_run(tmp_xdg, fake_timers):
+    with patch("plantimager.controller.scanner.powermanager.gpio.setup"), \
+         patch("plantimager.controller.scanner.powermanager.gpio.write"), \
+         patch("plantimager.controller.scanner.timelapse.PlantDBClient"), \
+         patch("plantimager.controller.scanner.timelapse.Scan") as MockScan:
+        MockScan.return_value.scan.return_value = None
+        MockScan.return_value._start_time = 0
+        MockScan.return_value._stop_time = 1
+        MockScan.return_value.status = "succeeded"
+        MockScan.return_value.error = None
+        MockScan.return_value.scan_id = "x"
+        from plantimager.controller.scanner.dummy_cnc import DummyCNC
+        cfg = _minimal_config(mode="interval", interval=3600, n_shots=3, grace_period=60)
+        pm = PowerManager(warmup_period=5)
+        with freezegun.freeze_time("2026-08-28 12:05:00+00:00"):
+            tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-skip", config=cfg, power_manager=pm)
+            # overwrite auto-generated schedule with known times
+            base = datetime.datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+            tl.schedule_times = [base, base + datetime.timedelta(seconds=60), base + datetime.timedelta(minutes=10)]
+            tl.next_idx = 0
+            # first two are overdue beyond grace (300s and 240s ago), third is future (5min)
+            tl._setup_next_scan_timer()
+            assert tl.next_idx == 2
+            # third timer armed, not yet executed
+            assert tl._next_scan_timer.isActive()
+
+
+# ---------------------------------------------------------------------------
+# 3. Power AUTO vs SCAN
+# ---------------------------------------------------------------------------
+def test_power_auto_vs_scan(tmp_xdg, fake_timers):
+    with patch("plantimager.controller.scanner.powermanager.gpio.setup"), \
+         patch("plantimager.controller.scanner.powermanager.gpio.write"), \
+         patch("plantimager.controller.scanner.timelapse.PlantDBClient"):
+        from plantimager.controller.scanner.dummy_cnc import DummyCNC
+        cfg_far = _minimal_config(mode="interval", interval=3600, n_shots=1, grace_period=10, standby_threshold_sec=60, warmup_period=5)
+        pm = PowerManager(warmup_period=5)
+        from freezegun import freeze_time
+        with freeze_time("2026-08-28 12:00:00+00:00"):
+            tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-power", config=cfg_far, power_manager=pm)
+            far = datetime.datetime.now(timezone.utc) + datetime.timedelta(seconds=3600)
+            tl.schedule_times = [far]
+            tl.next_idx = 0
+            tl._setup_next_scan_timer()
+            assert pm.mode == PowerManagerMode.AUTO
+            assert tl._powerup_timer.isActive()
+
+        # close → SCAN
+        cfg_close = _minimal_config(mode="interval", interval=60, n_shots=1, grace_period=10, standby_threshold_sec=600, warmup_period=5)
+        pm2 = PowerManager(warmup_period=5)
+        with freeze_time("2026-08-28 12:00:00+00:00"):
+            tl2 = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-power2", config=cfg_close, power_manager=pm2)
+            close = datetime.datetime.now(timezone.utc) + datetime.timedelta(seconds=100)
+            tl2.schedule_times = [close]
+            tl2.next_idx = 0
+            tl2._setup_next_scan_timer()
+            assert pm2.mode == PowerManagerMode.SCAN
+
+
+# ---------------------------------------------------------------------------
+# 4. Deterministic id + persist (via mocked Scan) — also checks FSDB-safe
+# ---------------------------------------------------------------------------
+def test_deterministic_id_and_persist(tmp_xdg, fake_timers):
+    with patch("plantimager.controller.scanner.powermanager.gpio.setup"), \
+         patch("plantimager.controller.scanner.powermanager.gpio.write"), \
+         patch("plantimager.controller.scanner.timelapse.PlantDBClient"):
+        def fake_scan_ctor(cnc, db_client, cameras, path, scan_id, config, parent=None):
+            inst = MagicMock()
+            inst.scan_id = scan_id
+            inst.scan.return_value = None
+            inst._start_time = datetime.datetime.now(timezone.utc).timestamp()
+            inst._stop_time = inst._start_time + 1
+            inst.status = "succeeded"
+            inst.error = None
+            return inst
+
+        with patch("plantimager.controller.scanner.timelapse.Scan", side_effect=fake_scan_ctor) as MockScan:
+            from plantimager.controller.scanner.dummy_cnc import DummyCNC
+            cfg = _minimal_config(mode="interval", interval=60, n_shots=1, grace_period=120)
+            pm = PowerManager(warmup_period=5)
+            with patch.object(TimeLapse, "_setup_next_scan_timer", lambda self: None):
+                tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-id", config=cfg, power_manager=pm)
+            sched = datetime.datetime(2025, 11, 24, 10, 0, 0, tzinfo=timezone.utc)
+            tl.schedule_times = [sched]
+            tl.next_idx = 0
+            # make delta within grace so scan proceeds (now = sched + 5s)
+            with freezegun.freeze_time(sched + datetime.timedelta(seconds=5)):
+                tl.scan(0)
+            # Scan ctor called with FSDB-safe id (positional arg 4)
+            assert MockScan.call_args[0][4] == f"tl-id--{tl._slug_for_schedule(sched)}"
+            assert ":" not in MockScan.call_args[0][4]
+            # persisted store contains one ScanRecord
+            store = TimelapseStore.new_store_from_last()
+            assert len(store.scans) == 1
+            assert store.scans[0]["scan_id"].startswith("tl-id--")
+
+
+# ---------------------------------------------------------------------------
+# 5. Resume after restart (new process simulation)
+# ---------------------------------------------------------------------------
+def test_resume_after_restart(tmp_xdg, fake_timers):
+    with patch("plantimager.controller.scanner.powermanager.gpio.setup"), \
+         patch("plantimager.controller.scanner.powermanager.gpio.write"), \
+         patch("plantimager.controller.scanner.timelapse.PlantDBClient"), \
+         patch("plantimager.controller.scanner.timelapse.Scan") as MockScan:
+        MockScan.return_value.scan.return_value = None
+        MockScan.return_value._start_time = 0
+        MockScan.return_value._stop_time = 1
+        MockScan.return_value.status = "succeeded"
+        MockScan.return_value.error = None
+        MockScan.return_value.scan_id = "x"
+        from plantimager.controller.scanner.dummy_cnc import DummyCNC
+        cfg = _minimal_config(mode="interval", interval=60, n_shots=3, grace_period=60)
+        pm = PowerManager(warmup_period=5)
+        with patch.object(TimeLapse, "_setup_next_scan_timer", lambda self: None):
+            tl = TimeLapse(cnc=DummyCNC(), db_url="http://dummy", cameras=[], path=[], timelapse_name="tl-resume", config=cfg, power_manager=pm)
+        base = datetime.datetime.now(timezone.utc)
+        tl.schedule_times = [base + datetime.timedelta(seconds=60*i) for i in range(3)]
+        tl.next_idx = 1
+        tl.state = TimeLapseState.SCHEDULED
+        # persist
+        from plantimager.controller.scanner.timelapse_store import TimelapseStore
+        TimelapseStore.from_timelapse(tl).save()
+        # new process
+        loaded = TimelapseStore.new_store_from_last()
+        kwargs = loaded.to_timelapse_kwargs()
+        assert kwargs["next_idx"] == 1
+        assert len(kwargs["schedule_times"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# 6. Live DB — opt-in, creates real scans in FSDB (one dataset per time)
+# ---------------------------------------------------------------------------
+@pytest.mark.live_db
+def test_live_db_timelapse_creates_scans(tmp_xdg):
+    # This test spawns a real FSDB REST API — heavy, only run with -m live_db
+    # Mock hardware, live DB
+    db_port = 23657
+    db_url = f"http://localhost:{db_port}"
+    plantdb_proc = subprocess.Popen(
+        ["fsdb_rest_api", "--test", "--empty", "--host", "localhost", "--port", str(db_port)],
+        env=os.environ,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    # wait for FSDB to be ready (poll)
+    from plantdb.client.plantdb_client import PlantDBClient as _WaitClient
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        try:
+            c = _WaitClient(db_url)
+            try:
+                c.login("admin", "admin")
+            except Exception:
+                pass
+            c.list_scans()
+            break
+        except Exception:
+            time.sleep(0.5)
+    else:
+        pytest.skip("FSDB not ready on port 23657")
+    try:
+        from plantdb.client.plantdb_client import PlantDBClient
+        from plantimager.controller.scanner.dummy_cnc import DummyCNC
+        from plantimager.controller.scanner.path import Circle
+
+        # need gpio mock still? PowerManager will try gpio.setup — patch before import? we patch at runtime
+        with patch("plantimager.controller.scanner.powermanager.gpio.setup"), \
+             patch("plantimager.controller.scanner.powermanager.gpio.write"), \
+             patch("plantimager.controller.scanner.timelapse.QTimer", FakeTimer), \
+             patch("plantimager.controller.scanner.powermanager.QTimer", FakeTimer):
+            # small fake camera
+            mock_cam = MagicMock()
+            mock_cam.name = "cam1"
+            from concurrent.futures import Future
+            f = Future(); f.set_result((b"fake", {"format": "jpg"}))
+            mock_cam.getImage.return_value = f
+
+            pm = PowerManager(warmup_period=1)
+            # use INTERVAL n=2 with tiny interval for speed; center 370 is safely inside DummyCNC 0-740
+            cfg = {
+                "ScanPath": {"class_name": "Circle", "kwargs": {"center_x": 370, "center_y": 370, "z": 10, "tilt": 0, "radius": 10, "n_points": 2}},
+                "Metadata": {"object": {"species": "live-test"}, "hardware": {"model": "dummy"}},
+                "timelapse": {"mode": "interval", "interval": 2, "n_shots": 2, "warmup_period": 0, "grace_period": 60, "standby_threshold_sec": 600},
+                "cam1": {"res_x": 640, "res_y": 480, "offset": {"x":0,"y":0,"z":0,"pan":0,"tilt":0}, "encoding": "jpg", "config": {}},
+            }
+            # create PlantDB client that will talk to live FSDB
+            from plantdb.client.plantdb_client import PlantDBClient as RealClient
+            # TimeLapse will create its own PlantDBClient internally; we also need one for assertions
+            # Patch Timelapse to use real client? Let it create via db_url
+            # create authenticated client and inject into TimeLapse
+            from plantdb.commons.auth.models import Permission
+            auth_client = RealClient(db_url)
+            auth_client.login("admin", "admin")
+            # ensure DB is ready
+            for _ in range(10):
+                try:
+                    auth_client.list_scans()
+                    break
+                except Exception:
+                    time.sleep(0.5)
+            # use admin client directly (has full rights) — no restricted token needed for test
+            tl = TimeLapse(cnc=DummyCNC(), db_url=db_url, cameras=[mock_cam], path=[], timelapse_name="tl-live", config=cfg, power_manager=pm)
+            tl.db_client = auth_client  # admin session, can create any scan
+            # override schedule to now+1s and now+3s to be fast
+            now = datetime.datetime.now(timezone.utc)
+            tl.schedule_times = [now + datetime.timedelta(seconds=1), now + datetime.timedelta(seconds=3)]
+            tl.start_at = tl.schedule_times[0]
+            tl.next_idx = 0
+            tl.grace_period = 60
+            # wait for both scans to fire
+            tl._trigger_next_scan()
+            tl._trigger_next_scan()
+            # assert DB has two scans with deterministic ids
+            client = auth_client
+            scans = client.list_scans()
+            # scans are prefixed with tl-live--
+            live = [s for s in scans if s.startswith("tl-live--")]
+            assert len(live) == 2
+            # each has timelapse grouping via scan_id prefix; verify filesets exist
+            for sid in live:
+                fs = client.list_scan_filesets(sid)
+                assert "images" in fs["filesets"] or "images" in str(fs)
+    finally:
+        if plantdb_proc.poll() is None:
+            plantdb_proc.send_signal(signal.SIGINT)
+            try:
+                plantdb_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                plantdb_proc.kill()
+

--- a/test/test_timelapse_integration.py
+++ b/test/test_timelapse_integration.py
@@ -149,7 +149,7 @@ def test_power_auto_vs_scan(tmp_xdg, fake_timers):
             tl.next_idx = 0
             tl._setup_next_scan_timer()
             assert pm.mode == PowerManagerMode.AUTO
-            assert tl._powerup_timer.isActive()
+            assert pm.warmup_timer.isActive()
 
         # close → SCAN
         cfg_close = _minimal_config(mode="interval", interval=60, n_shots=1, grace_period=10, standby_threshold_sec=600, warmup_period=5)

--- a/test/test_timelapse_store.py
+++ b/test/test_timelapse_store.py
@@ -1,0 +1,169 @@
+# test_timelapse_store.py
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from unittest import mock
+
+# The module under test
+from plantimager.controller.scanner.timelapse_store import TimelapseStore, ScanRecord, TIMELAPSE_STORAGE_JSON
+from plantimager.controller.scanner.timelapse import TimeLapseState, TimeLapseMode
+
+
+class DummyTimeLapse:
+    """Minimal stand‑in for the real TimeLapse class."""
+    def __init__(self):
+        self.id = "tl-123"
+        self.mode = TimeLapseMode.FIXED_TIMES
+        self._state = TimeLapseState.STANDBY
+        self.schedule_times = [
+            datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc),
+            datetime(2023, 1, 1, 14, 0, tzinfo=timezone.utc),
+        ]
+        self.next_idx = 1
+        self.current_idx = 0
+        self.warmup_sec = 10
+        self.standby_threshold_sec = 20
+        self.grace_period = 5
+        self.start_at = datetime(2023, 1, 1, 11, 30, tzinfo=timezone.utc)
+
+        # Simulate a couple of finished scans
+        class DummyScan:
+            def __init__(self, scan_id, start_ts, stop_ts, status, error=None):
+                self.scan_id = scan_id
+                self._start_time = start_ts
+                self._stop_time = stop_ts
+                self.status = status
+                self.error = error
+
+        self.scans = [
+            DummyScan(
+                "scan-1",
+                datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc).timestamp(),
+                datetime(2023, 1, 1, 12, 5, tzinfo=timezone.utc).timestamp(),
+                "succeeded",
+            ),
+            DummyScan(
+                "scan-2",
+                datetime(2023, 1, 1, 14, 0, tzinfo=timezone.utc).timestamp(),
+                datetime(2023, 1, 1, 14, 2, tzinfo=timezone.utc).timestamp(),
+                "failed",
+                error={"msg": "something went wrong"},
+            ),
+        ]
+
+
+class TimelapseStoreTest(unittest.TestCase):
+    def setUp(self):
+        # Create an isolated directory and point the store to it
+        self.tmp_dir = tempfile.TemporaryDirectory(prefix="pi3_test_timelapse_store")
+        self.addCleanup(self.tmp_dir.cleanup)
+
+        self.patcher_xdg = mock.patch.dict(os.environ, {"XDG_DATA_HOME": self.tmp_dir.name})
+        self.patcher_xdg.start()
+        self.addCleanup(self.patcher_xdg.stop)
+
+    def _store_path(self):
+        return pathlib.Path(self.tmp_dir.name) / "plant-imager3-app" / "timelapse_storage.json"
+
+    def test_save_and_load_cycle(self):
+        """Store a value, write it to disk, reload and compare."""
+        store = TimelapseStore(
+            timelapse_id="abc",
+            mode="auto",
+            state="running",
+            schedule_times=[
+                "2023-01-01T12:00:00+00:00",
+                "2023-01-01T14:00:00+00:00",
+            ],
+            next_idx=1,
+            current_idx=0,
+            warmup_sec=10,
+            standby_threshold_sec=20,
+            grace_period=5,
+            start_at="2023-01-01T11:30:00+00:00",
+            scans=[
+                {"scan_id": "s1", "started_at": None, "finished_at": None, "status": "pending", "error": None}
+            ],
+            extra={"foo": "bar"},
+        )
+
+        # Save to the temporary location
+        store.save()
+        self.assertTrue(self._store_path().is_file(), "JSON file should exist after save()")
+
+        # Load it back via the classmethod
+        loaded = TimelapseStore.new_store_from_last()
+        self.assertIsNotNone(loaded, "new_store_from_last should return an object when file exists")
+
+        # Compare a few representative fields
+        self.assertEqual(store.timelapse_id, loaded.timelapse_id)
+        self.assertEqual(store.mode, loaded.mode)
+        self.assertEqual(store.state, loaded.state)
+        self.assertEqual(store.schedule_times, loaded.schedule_times)
+        self.assertEqual(store.scans, loaded.scans)
+        self.assertEqual(store.extra, loaded.extra)
+
+        # Verify that the raw JSON contains the version key
+        with self._store_path().open("r", encoding="utf-8") as f:
+            raw = json.load(f)
+        self.assertIn("version", raw)
+        self.assertEqual(raw["version"], store.version)
+
+    def test_from_timelapse_and_to_kwargs_roundtrip(self):
+        """Serialize a dummy TimeLapse, then deserialize via to_timelapse_kwargs."""
+        dummy = DummyTimeLapse()
+        store = TimelapseStore.from_timelapse(dummy)
+
+        # Basic sanity checks on the generated store
+        self.assertEqual(store.timelapse_id, dummy.id)
+        self.assertEqual(store.mode, dummy.mode.value)
+        self.assertEqual(store.state, dummy._state.value)
+        self.assertEqual(len(store.schedule_times), 2)
+        self.assertEqual(store.next_idx, dummy.next_idx)
+        self.assertEqual(store.current_idx, dummy.current_idx)
+
+        # Ensure scans are stored as dicts with proper fields
+        self.assertEqual(len(store.scans), 2)
+        self.assertIn("scan_id", store.scans[0])
+        self.assertIn("started_at", store.scans[0])
+
+        # Convert back to kwargs and verify types
+        kwargs = store.to_timelapse_kwargs()
+        self.assertIsInstance(kwargs["schedule_times"][0], datetime)
+        self.assertIsInstance(kwargs["start_at"], datetime)
+
+        # The scans list should contain actual ScanRecord instances
+        self.assertTrue(all(isinstance(s, ScanRecord) for s in kwargs["scans"]))
+
+    def test_load_missing_file_returns_none(self):
+        """When the JSON file does not exist, new_store_from_last should return None."""
+        # Ensure the file truly does not exist
+        path = self._store_path()
+        if path.is_file():
+            path.unlink()
+        self.assertFalse(path.is_file())
+
+        result = TimelapseStore.new_store_from_last()
+        self.assertIsNone(result, "Expected None when no persisted file is present")
+
+    def test_version_mismatch_is_handled_gracefully(self):
+        """A stored version different from the class default should still load."""
+        store = TimelapseStore(timelapse_id="ver-test")
+        # Manually write a JSON with a mismatching version
+        bad_json = store._as_serialisable_dict()
+        bad_json["version"] = 999  # unrealistic future version
+        self._store_path().parent.mkdir(exist_ok=True, parents=True)
+        with open(self._store_path(), "w", encoding="utf-8") as f:
+            json.dump(bad_json, f)
+
+        # Loading must not raise; it should return an object with the stored version
+        loaded = TimelapseStore.new_store_from_last()
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.version, 999)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_timelapse_store.py
+++ b/test/test_timelapse_store.py
@@ -17,7 +17,7 @@ class DummyTimeLapse:
     def __init__(self):
         self.id = "tl-123"
         self.mode = TimeLapseMode.FIXED_TIMES
-        self._state = TimeLapseState.STANDBY
+        self._state = TimeLapseState.SCHEDULED
         self.schedule_times = [
             datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc),
             datetime(2023, 1, 1, 14, 0, tzinfo=timezone.utc),
@@ -73,7 +73,7 @@ class TimelapseStoreTest(unittest.TestCase):
         store = TimelapseStore(
             timelapse_id="abc",
             mode="auto",
-            state="running",
+            state="scheduled",
             schedule_times=[
                 "2023-01-01T12:00:00+00:00",
                 "2023-01-01T14:00:00+00:00",


### PR DESCRIPTION
Adding timelapse scan functionality following the plan:

# Plant-Imager3: Time-Lapse

## Objectives

Here are the various objectives expected for the Plant-Imager to perform a time-lapse reconstruction:

 1. Capture at fixed intervals or at fixed dates the subject
 2. Being able to configure a time-lapse via the webui
 3. Do not accept new time-lapse order while one is running
 4. Resume current time-lapse in case of restart of the plantimager-app
 5. Switch on and off various part of the Plant-Imager as they are required or not
 6. Warn the user in case of faillure and cause of faillure
 7. Warn the user when a time-lapse ends


Auxillary objectives:
 
 - Adapt plantdb for time-lapses (multiple filesets ?)


## Plan

### 1. time-lapse

#### New Scan and TimeLapse class

A `TimeLapse` represents the process of capturing the subject and consists of one or multiple `Scan`. The `Scanner` effectuate the scan of the plant through the `TimeLapse` class and can only have one `TimeLapse` at a time (3.). 

A `Scan` is a 3D capture of the plant at a given time, moving through the path once and captures by the cameras at each point.

The current status (no time-lapse) is one `TimeLapse` which does one `Scan`.

Each `Scan` is time-coded for the start time, finish time then recorded.

The `Scanner` wakes up the machine (5.) before a `Scan` is due and starts it on time (1.).

When a `Scan` is finished the `Scanner` evaluates if the next `Scan` (if there is one) is scheduled to take place less than a set ammount of time later. If True the scanner remains on standby. If False, the `Scanner` powers down the `CNC` and turn down the lights or switch to growth lights depending on the time and the parameters of the `TimeLapse` (5.)


#### Current Scan recovery

The current Scan configuration is stored in a JSON file on the disk in a non-temporary folder. On startup, the plantimager-app checks this file to see if a scan was already in progress. If it is the case the scan is loaded back and resumed. (4.)

#### Interface

When a Scan is configured a new interface is created where its configuration can be reviewed. The information displayed include the path configured and the various time-points planned. The time-points already executed are marked as completed.

On the main interface in the scanner area (bottom left), the current (planned) timestamp is displayed during a capture, otherwise the next timestamp and the time to said timestamp.

A secondary progress-bar is displayed to represent the progression of the number of `Scan`s

#### Webui

New sections in the configuration toml (2.):
 - timelapse
     - mode ["interval", "fixed_times", "one_shot"]
     - interval
     - grace_period
     - warmup_period
     - time-points
 - light-control
 - email (to warn the user in case of failure (6. 7.))

*optionaly*: create a configuration wizard


### 2. hardware

The main changes in hardware are done to allow the plant-imager controller (RasPi) to turn on and off various part of the scanner (cnc, lights, growth lights). This is done to allow coordination and power-savings (5.).

The power supply of the different parts must be seperated.

For switching the different parts a two stage design is used. The first stage is a low-voltage relay board that is controlled by the plant-imager controller through the GPIO pins. This first stage then controls the second stage, each relay controlling a high(er)-voltage power relay.

Additionnal change of the led bands possible.

+ electro-magnet lock for the door when Scan is running

