### PR TITLE
Provide comprehensive documentation, refactor RPC, and add unit tests

### DIFF
--- a/docs/developer/RPC.md
+++ b/docs/developer/RPC.md
@@ -106,24 +106,20 @@ sequenceDiagram
     activate client
     Note over server: The method serve_forever() must have been called
     Note over client: in __init__ after <br/> the socket is connected
-    client->>+server: FIND_PEER_ADDRESS
-    Note right of server: Creates a socket server
-    server->>client: url
-    client<<-->>server: connects to temp server
-    deactivate server
+
     
     
     Note over client,server: Getting peer address and <br/> closing connection and temporary server
     client->>+server: GET_INVENTORY
-    server->>-client: methods, properties and signals inventory
+    server->>-client: methods, timeouts, properties and signals inventory
 
     opt RPCSignals declared
-    Note over signal_recv, client: Start Signal Receiver thread
+    client->>+server: INIT_SIGNALS_HANDLING
+    Note right of server: Creates signal publisher socket and <br/> connect signals to _send_signal()
+    server->>-client: success, signal_port
+    Note over signal_recv, client: Start Signal Receiver thread <br/> and subsrcibe to publisher
     client->>+signal_recv: __init__()
     signal_recv-->>-client: 
-    client->>+server: INIT_SIGNALS_HANDLING
-    Note right of server: Connect to signal socket and <br/> connect signals to _send_signal()
-    server->>-client: success
 
     end
 
@@ -175,24 +171,13 @@ sequenceDiagram
     Note over recv, server: server.serve_forever() called <br/> and client connected
 
     Note over server_signal: emit() called
-    activate server_signal
     server_signal->>+server: _send_signal()
     server->>+recv: EMIT_SIGNAL
-    Note over recv: select corresponding signal
-    alt is blocking
-        recv->>+client_signal: emit()
-        client_signal-->>-recv: 
-        recv->>server: success
-    else
-        recv->>server: success
-        recv->>+client_signal: emit()
-        client_signal-->>-recv: 
-        deactivate recv
-    end
-    
-
     server-->>-server_signal: 
-    deactivate server_signal
+    Note over recv: select corresponding signal
+    recv->>+client_signal: emit()
+    client_signal-->>-recv: 
+    deactivate recv
 ```
 
 ### Property getter

--- a/src/commons/plantimager/commons/RPC.py
+++ b/src/commons/plantimager/commons/RPC.py
@@ -21,30 +21,38 @@ RPCServer
 import copy
 import inspect
 import json
+import logging
 import re
 import sys
 import time
 import traceback
-import logging
 import weakref
 from enum import StrEnum
-from functools import wraps, partial
+from functools import partial
+from functools import wraps
 from threading import Thread
-from typing import Callable, Any
-from weakref import finalize, WeakMethod
+from typing import Any
+from typing import Callable
+from weakref import WeakMethod
+from weakref import finalize
 
 import zmq
 from decorator import decorate
 from zmq import ZMQBindError
 
-from plantimager.commons.utils import is_instance_of_generic, coerce_to_generic
-from plantimager.commons.deviceregistry import register_device, unregister_device, send_alive_check, AliveCheckState
+from plantimager.commons.deviceregistry import AliveCheckState
+from plantimager.commons.deviceregistry import register_device
+from plantimager.commons.deviceregistry import send_alive_check
+from plantimager.commons.deviceregistry import unregister_device
 from plantimager.commons.logging import create_logger
 from plantimager.commons.systemd import notify_watchdog
+from plantimager.commons.utils import coerce_to_generic
+from plantimager.commons.utils import is_instance_of_generic
 
 __all__ = ["RPCClient", "RPCServer", "RPCProperty", "RPCSignal", "NoResult"]
 
 logger = create_logger("RPC")
+
 
 class RPCEvents(StrEnum):
     """
@@ -58,6 +66,7 @@ class RPCEvents(StrEnum):
     STOP_SERVER = "STOP_SERVER"
     INIT_SIGNALS_HANDLING = "INIT_SIGNALS_HANDLING"
     EMIT_SIGNAL = "EMIT_SIGNAL"
+
 
 url_parser = re.compile(r"([a-zA-Z]*)://([a-zA-Z.0-9]*):?(\d*)")
 
@@ -82,6 +91,7 @@ class NoResult:
         A string containing the traceback or detailed information
         about where and why the failure occurred.
     """
+
     def __init__(self, error: str, traceback: str):
         self.error = error
         self.traceback = traceback
@@ -89,27 +99,29 @@ class NoResult:
     def __bool__(self):
         return False
 
+
 class RPCSignal:
-    """RPCSignal
-    ---------
-    Lightweight publish‑subscribe signal implementation that stores either strong
-    or weak references to callables and invokes them with supplied arguments.
+    """
+    Lightweight publish‑subscribe signal implementation.
+
+    This class stores either strong or weak references to callables and invokes
+    them with supplied arguments.
 
     Instances are created with a variable number of *type specifications* that
-    describe the expected arguments for the signal.  These specifications are
+    describe the expected arguments for the signal. These specifications are
     stored unchanged in the :attr:`args` attribute; they are **not** validated at
     runtime but may be used by callers for documentation or static checking.
 
     Connections are added via :meth:`connect` and removed via :meth:`disconnect`.
     When the signal is emitted with :meth:`emit`, each stored connection is called
-    in the order it was added.  Weak references that have been garbage‑collected
+    in the order it was added. Weak references that have been garbage‑collected
     are silently ignored.
 
     Parameters
     ----------
     *arg_types : tuple
         Positional argument type specifications supplied at construction time.
-        The contents are opaque to the implementation – they are kept only for
+        The contents are opaque to the implementation - they are kept only for
         external introspection.
 
     Attributes
@@ -118,17 +130,27 @@ class RPCSignal:
         The positional argument type specifications supplied to ``__init__``.
         Callers may inspect this attribute for documentation or validation
         purposes.
-
     connections : list
-        Mutable list of connected callables or weak references.  Each entry is
-        either a callable object or a :class:`weakref.WeakMethod`.  The list is
-        modified by :meth:`connect` and :meth:`disconnect`.  Callables are
+        A mutable list of connected callables or weak references. Each entry is
+        either a callable object or a :class:`weakref.WeakMethod`. The list is
+        modified by :meth:`connect` and :meth:`disconnect`. Callables are
         invoked in the order they were added when :meth:`emit` is called.
 
     See Also
     --------
     weakref.WeakMethod : Standard library class used to store weak references to bound methods.
+
+    Examples
+    --------
+    >>> from plantimager.commons.RPC import RPCSignal
+    >>> def listener(x, y): print(f"Received: {x}, {y}")
+    >>> signal = RPCSignal(int, str)
+    >>> signal.connect(listener)
+    >>> signal.emit(10, "hello")
+    Received: 10, hello
+    >>> signal.disconnect(listener)
     """
+
     def __init__(self, *arg_types):
         """
         Initialize a new ``RPCSignal`` instance.
@@ -136,7 +158,7 @@ class RPCSignal:
         Parameters
         ----------
         *arg_types : tuple
-            Positional argument type specifications.  The values are stored in
+            Positional argument type specifications. The values are stored in
             :attr:`args` but are otherwise not interpreted by the signal.
 
         Notes
@@ -146,18 +168,17 @@ class RPCSignal:
         argument types for the signal.
         """
         self.arg_types = arg_types
-        self.connections = []
-        self.args = arg_types
         self.connections: list[Callable | WeakMethod] = []
 
     def emit(self, *args):
-        """Emit the signal, invoking all connected callables.
+        """
+        Emit the signal, invoking all connected callables.
 
         Parameters
         ----------
         *args : tuple
             Positional arguments that will be forwarded to each connected
-            callable.  The number and type of arguments should match the
+            callable. The number and type of arguments should match the
             specifications stored in :attr:`args`, but this is not enforced.
 
         Notes
@@ -166,11 +187,20 @@ class RPCSignal:
           before the call; if the underlying object has been garbage‑collected,
           the entry is simply skipped.
         - Any exception raised by a connected callable propagates to the caller
-          of :meth:`emit`.  The method does **not** catch or suppress errors.
+          of :meth:`emit`. The method does **not** catch or suppress errors.
+
+        Examples
+        --------
+        >>> from plantimager.commons.RPC import RPCSignal
+        >>> def listener(x, y): print(f"Received: {x}, {y}")
+        >>> signal = RPCSignal(int, str)
+        >>> signal.connect(listener)
+        >>> signal.emit(10, "hello")
+        Received: 10, hello
         """
         args = self.validate_args(*args, coerce=True)
         for conn in self.connections:
-            if isinstance(conn, WeakMethod) and (func:=conn()):
+            if isinstance(conn, WeakMethod) and (func := conn()):
                 # If the onnection is a WeakMethod and the method still lives
                 func(*args)
             elif not isinstance(conn, weakref.WeakMethod):
@@ -230,7 +260,8 @@ class RPCSignal:
         return tuple(new_args)
 
     def connect(self, conn: Callable | WeakMethod):
-        """Connect a callable (or weak reference) to the signal.
+        """
+        Connect a callable (or weak reference) to the signal.
 
         Parameters
         ----------
@@ -246,19 +277,29 @@ class RPCSignal:
         Notes
         -----
         The same ``conn`` is added only once; duplicate connections are ignored.
+
+        Examples
+        --------
+        >>> from plantimager.commons.RPC import RPCSignal
+        >>> def listener(x, y): print(f"Received: {x}, {y}")
+        >>> signal = RPCSignal(int, str)
+        >>> signal.connect(listener)
+        >>> signal.emit(10, "hello")
+        Received: 10, hello
         """
         if not isinstance(conn, (weakref.WeakMethod, Callable)):
             raise TypeError("Expected callable or weakref.WeakMethod, got {}".format(type(conn)))
         if conn not in self.connections:
             self.connections.append(conn)
 
-    def disconnect(self, conn: Callable=None):
-        """Remove a previously connected callable or clear all connections.
+    def disconnect(self, conn: Callable = None):
+        """
+        Remove a previously connected callable or clear all connections.
 
         Parameters
         ----------
         conn : Callable, optional
-            The specific callable or weak reference to remove.  If omitted (or
+            The specific callable or weak reference to remove. If omitted (or
             ``None``), *all* connections are cleared.
 
         Raises
@@ -270,6 +311,17 @@ class RPCSignal:
         -----
         After a successful call, the target is no longer invoked by future
         :meth:`emit` calls.
+
+        Examples
+        --------
+        >>> from plantimager.commons.RPC import RPCSignal
+        >>> def listener(x, y): print(f"Received: {x}, {y}")
+        >>> signal = RPCSignal(int, str)
+        >>> signal.connect(listener)
+        >>> signal.emit(10, "hello")
+        Received: 10, hello
+        >>> signal.disconnect(listener)
+        >>> signal.emit(10, "hello")
         """
         if conn:
             self.connections.remove(conn)
@@ -282,9 +334,9 @@ class RPCProperty(property):
     RPC-enabled property descriptor.
 
     This subclass of :class:`property` adds optional notification support
-    via an :class:`RPCSignal`.  When a property created with ``RPCProperty``
+    via an :class:`RPCSignal`. When a property created with ``RPCProperty``
     is assigned a new value, the supplied ``notify`` signal (if provided)
-    can be emitted to inform remote listeners of the change.  The class is
+    can be emitted to inform remote listeners of the change. The class is
     typically used as a decorator on a getter function; the optional
     ``notify`` argument is stored on the resulting property object and can
     be accessed by custom setter implementations.
@@ -300,12 +352,13 @@ class RPCProperty(property):
         When True, when the setter of the property is called and the value is
           modified, the _notifier is emitted.
     """
+
     def __init__(self, fget=None, fset=None, fdel=None, doc=None, notify: RPCSignal = None, auto_notify=False):
         """
         Initialize the property with optional RPC notification.
 
         This subclass of ``property`` adds support for emitting an RPC signal
-        when the property value changes.  If ``auto_notify`` is ``True`` the
+        when the property value changes. If ``auto_notify`` is ``True`` the
         signal provided via ``notify`` is emitted automatically after a successful
         set operation; otherwise the caller must trigger the notification
         manually.
@@ -350,7 +403,7 @@ class RPCProperty(property):
         4. If ``old != new`` and a notifier exists, emit the signal with the
            new value.
         """
-        # Step 1 – capture the old value (may be None if no getter)
+        # Step 1 - capture the old value (may be None if no getter)
         old_val = None
         if self._auto_notify and self.fget is not None:
             try:
@@ -360,10 +413,10 @@ class RPCProperty(property):
                 # the change‑detection will fall back to always emit.
                 old_val = object()  # unique sentinel
 
-        # Step 2 – invoke the original setter (if any)
+        # Step 2 - invoke the original setter (if any)
         super().__set__(obj, value)
 
-        # Step 3 – capture the new value via the getter (if any)
+        # Step 3 - capture the new value via the getter (if any)
         new_val = None
         if self._auto_notify and self.fget is not None:
             try:
@@ -371,14 +424,13 @@ class RPCProperty(property):
             except Exception:
                 new_val = object()  # unique sentinel
 
-        # Step 4 – emit if changed and a notifier is present
+        # Step 4 - emit if changed and a notifier is present
         if self._auto_notify and self._notifier is not None and old_val != new_val:
             try:
                 self._notifier.emit(new_val)
             except Exception as exc:
                 # We never want a notification failure to break the setter.
                 logger.error(f"Failed to emit RPCProperty change signal: {exc}")
-
 
 
 class RPCSignalReceiver(Thread):
@@ -389,29 +441,55 @@ class RPCSignalReceiver(Thread):
     polls for incoming signal events. When a signal is received, it emits the
     corresponding proxy signal on the client side.
 
-    Parameters
+    Attributes
     ----------
     context : zmq.Context
         The ZeroMQ context used to create the socket.
     url : str
         The base URL to bind the receiver socket (e.g., "tcp://127.0.0.1").
-    signals : dict of str to RPCSignal
+    signals : dict[str, RPCSignal]
         A dictionary mapping signal names to their corresponding `RPCSignal`
         instances on the client.
-
-    Attributes
-    ----------
-    port : int
-        The randomly selected port number this receiver is bound to.
+    socket : zmq.Socket
+        A ZeroMQ SUB socket that receives broadcasted signal events from the server.
+    _stop_flag : bool
+        A flag used by `run()` to know when to exit the loop.
     """
+
     def __init__(self, context: zmq.Context, url: str, signals: dict[str, RPCSignal]):
+        """
+        Initialize a new `RPCSignalReceiver`.
+
+        Parameters
+        ----------
+        context : zmq.Context
+            The ZeroMQ context used to create the socket.
+        url : str
+            The base URL of the server's ``PUB`` endpoint (e.g. ``"tcp://127.0.0.1"``).
+        signals : dict[str, RPCSignal]
+            Dictionary mapping signal names to the corresponding
+            `RPCSignal` instances on the client.
+
+        Notes
+        -----
+        The underlying socket is a ``SUB`` socket that subscribes to *all*
+        topics (``socket.setsockopt_string(zmq.SUBSCRIBE, "")``). This class
+        does not expose the socket directly; use the public attributes if
+        custom behaviour is required.
+
+        Raises
+        ------
+        TypeError
+            If ``context`` is not a :class:`zmq.Context` instance, ``url`` is not
+            a string, or ``signals`` is not a ``dict`` with string keys.
+        """
         super().__init__(name="RPCSignalReceiver")
         self.context = context
         self.url = url  # now the server's PUB endpoint
         self._stop_flag = False
         self.signals = signals
         self.socket: zmq.Socket = context.socket(zmq.SUB)
-        self.socket.connect(url)
+        self.socket.connect(url)  # connect to the server's PUB endpoint
         self.socket.setsockopt_string(zmq.SUBSCRIBE, "")  # subscribe to all
 
     def run(self):
@@ -439,6 +517,19 @@ class RPCSignalReceiver(Thread):
         RuntimeError
             If an error occurs while emitting a signal.
 
+        Examples
+        --------
+        >>> import zmq
+        >>> from threading import Thread
+        >>> from plantimager.commons.RPC import RPCSignal
+        >>> from plantimager.commons.RPC import RPCSignalReceiver
+        >>> ctx = zmq.Context()
+        >>> signals = {"update": RPCSignal()}
+        >>> receiver = RPCSignalReceiver(ctx, "tcp://127.0.0.1:5555", signals)
+        >>> receiver.start()               # start the background thread
+        >>> # ... elsewhere, the server publishes a signal ...
+        >>> receiver.stop()                # request graceful shutdown
+        >>> receiver.join()                # wait for the thread to finish
         """
         try:
             while not self._stop_flag:
@@ -463,6 +554,7 @@ class RPCSignalReceiver(Thread):
         """
         self._stop_flag = True
 
+
 class RPCClient:
     """
     Abstract base class for RPC clients.
@@ -471,24 +563,48 @@ class RPCClient:
     To use this, create a subclass that inherits from both a target interface
     and this class, and decorate it with `@RPCClient.register_interface`.
 
-    Parameters
-    ----------
-    context : zmq.Context
-        The ZeroMQ context used for networking.
-    url : str
-        The URL of the target RPC server to connect to.
-
     Attributes
     ----------
-    own_address : str
-        The local IP address of the client.
-    peer_address : str
-        The IP address of the connected RPC server.
+    context : zmq.Context
+        The ZeroMQ context used for creating sockets and managing connections.
+    url : str
+        The full URL (e.g., ``tcp://127.0.0.1:5555``) of the target RPC server.
+    socket : zmq.Socket
+        A ``REQ`` socket connected to ``url`` used for all RPC communication.
+    _json_methods : dict[str, int | None]
+        Mapping of JSON‑serialisable remote method names to their timeout values
+        (in milliseconds). Populated from the server inventory.
+    _buffer_methods : dict[str, int | None]
+        Mapping of buffer‑based remote method names to their timeout values.
+        Populated from the server inventory.
+    _signals : dict[str, RPCSignal]
+        Signals discovered from the server inventory; keys are signal names and
+        values are the corresponding ``RPCSignal`` instances bound to this client.
+    _properties : list
+        List of property names exposed by the server.
     name : str
-        The designated name of the connected RPC server.
+        The designated name of the connected RPC server (provided by the server
+        during inventory exchange).
+    own_address : str
+        The local IP address of the client (retrieved from the server inventory).
+    peer_address : str
+        The IP address of the connected RPC server (retrieved from the server inventory).
+    _signal_receiver : RPCSignalReceiver | None
+        Background thread that receives and dispatches signals from the server.
+        ``None`` if the server does not expose any signals.
     """
 
     def __init__(self, context: zmq.Context, url: str, timeout=1000):
+        """
+        Initialize a new RPCClient.
+
+        Parameters
+        ----------
+        context : zmq.Context
+            The ZeroMQ context used for networking.
+        url : str
+            The URL of the target RPC server to connect to.
+        """
         super().__init__()
         self.context: zmq.Context = context
         self.url: str = url
@@ -510,9 +626,9 @@ class RPCClient:
             logger.error("Failed to get inventory. Server did not respond.")
             raise TimeoutError("Failed to get inventory.")
         reply = self.socket.recv_json()
-        logger.debug(f"Got inv: {reply}",)
-        self._json_methods: dict[str, int|None] = reply["json_methods"]
-        self._buffer_methods: dict[str, int|None] = reply["buffer_methods"]
+        logger.debug(f"Got inv: {reply}", )
+        self._json_methods: dict[str, int | None] = reply["json_methods"]
+        self._buffer_methods: dict[str, int | None] = reply["buffer_methods"]
         self._signals = {sig: getattr(self, sig) for sig in reply["signals"] if hasattr(self, sig)}
         self._properties: list = reply["properties"]
         self.name: str = reply["name"]
@@ -577,6 +693,7 @@ class RPCClient:
             If the decorated class does not inherit from both `interface`
             and `RPCClient`.
         """
+
         def _decorator(target_cls: type):
             if interface not in target_cls.__bases__ or cls not in target_cls.__bases__:
                 raise RuntimeError(f"{target_cls} must inherit from {interface} and {cls}.")
@@ -587,7 +704,7 @@ class RPCClient:
                     func.__isabstractmethod__ = False  # Counts as en actual implementation
                     setattr(target_cls, key, func)
                 elif isinstance(val, RPCSignal):
-                    pass # nothing to do at this stage
+                    pass  # nothing to do at this stage
                 elif isinstance(val, RPCProperty):
                     fget = wraps(val.fget)(partial(cls._property_getter_proxy, property_name=key))
                     fset = wraps(val.fset)(partial(cls._property_setter_proxy, property_name=key))
@@ -597,6 +714,7 @@ class RPCClient:
             target_cls.__abstractmethods__ = frozenset()
             target_cls._interface = interface.__name__
             return target_cls
+
         return _decorator
 
     @staticmethod
@@ -625,7 +743,7 @@ class RPCClient:
     def _property_getter_proxy(self, property_name: str) -> Any:
         package = {
             "event": RPCEvents.PROPERTY_GET,
-            "property":  property_name
+            "property": property_name
         }
         logger.debug(f"getting property {property_name}")
         self.socket.send_json(package, flags=zmq.NOBLOCK)
@@ -645,7 +763,7 @@ class RPCClient:
     def _property_setter_proxy(self, value: Any, property_name: str) -> None:
         package = {
             "event": RPCEvents.PROPERTY_SET,
-            "property":  property_name,
+            "property": property_name,
             "value": value
         }
         logger.debug(f"setting property {property_name} to {value}")
@@ -698,7 +816,7 @@ class RPCClient:
             if self.socket.poll(timeout=self._json_methods[method_name], flags=zmq.POLLIN) == 0:
                 logger.error(f"Proxy of {self._interface} at {self.url} did not respond")
                 raise TimeoutError(f"Proxy of {self._interface} at {self.url} did not respond")
-            reply =  self.socket.recv_json()
+            reply = self.socket.recv_json()
             if reply["success"]:
                 return True, reply["result"]
             else:
@@ -737,15 +855,69 @@ class RPCClient:
 
 
 class RPCServer:
+    """
+    RPCServer to use in combination with RPCClient.
 
+    The server holds the concrete implementation of an interface that is made available on the network.
+    To create an RPCServer create a class inheriting from an interface and RPCServer. Callable
+    methods must be decorated using `RPCServer.register_method_buffer` or `RPCServer.register_method_json`.
+    The server is also capable of sending signals defined by the RPCSignal class and proxying properties
+    defined with RPCProperty.
+
+    Attributes
+    ----------
+    context: zmq.Context
+        ZMQ context used to make the various sockets necessary for communicating with the client.
+    url: str
+        The base URL where the RPCServer is opened.
+        The url should include the port in the form ``tcp://<ip>:<port>``.
+    alive_timeout : int
+        Timeout (in seconds) used for ``alive`` checks against the device
+        registry. If the server cannot be reached for three consecutive checks
+        it is considered dead and will stop serving.    uuid : str | None
+        Unique identifier provided by the registry.  ``None`` until the server
+        is registered.
+    uuid : str | None
+        Unique identifier provided by the registry.  ``None`` until the server
+        is registered.
+    name: str
+        Name of the RPCServer assigned by the device registry after successful registration.
+    registry_addr : str
+        URL of the device registry to which the server is registered.
+        Empty string if the server has not been registered.
+    peer_addr : str | None
+        IP address of the connected client once a peer discovery request has
+        been processed.
+    _unreachable_counter : int
+        Counter of consecutive failed ``alive`` checks against the registry.
+        When the count reaches ``3`` the server is considered dead and will stop serving.
+    _json_methods : dict[str, Callable]
+        Mapping of method names to the underlying callables that are exposed as
+        JSON‑based RPC procedures.
+    _buffer_methods : dict[str, Callable]
+        Mapping of method names to the underlying callables that are exposed as
+        buffer‑based RPC procedures.
+    _rpc_properties : dict[str, RPCProperty]
+        RPC properties discovered on the class.
+    _signals : dict[str, RPCSignal]
+        Signal objects discovered on the class.
+    _socket : zmq.Socket[zmq.REP]
+        REP socket bound to ``url`` (or to a randomly chosen port when ``url`` does not
+        specify one) that receives incoming RPC requests.
+    port : int
+        The TCP port selected by :meth:`_bind_socket`. If the ``url`` does not
+        contain an explicit port, a random one in the range 10000-12000 is
+        chosen.
+    _signal_socket : zmq.Socket[zmq.REQ] | None
+        Socket used for sending signal notifications to the client.
+    _stop : bool
+        Flag controlling the termination of :meth:`serve_forever`.
+    _dead : bool
+        Indicates whether the server has already been shut down.
+    """
     def __init__(self, context: zmq.Context, url: str, alive_timeout: int = 60):
         """
-        RPCServer to use in combination with RPCClient.
-        The server holds the concrete implementation of an interface that is made available on the network.
-        To create an RPCServer create a class inheriting from an interface and RPCServer. Callable
-        methods must be decorated using `RPCServer.register_method_buffer` or `RPCServer.register_method_json`.
-        The server is also capable of sending signals defined by the RPCSignal class and proxying properties
-        defined with RPCProperty.
+        Initialize a new RPCServer.
 
         Parameters
         ----------
@@ -756,21 +928,6 @@ class RPCServer:
             of the local network interface ip which must be accessible from the client.
         alive_timeout: int, optional
             Time in seconds after which the device_registry will consider this service dead or unreachable.
-
-        Attributes
-        ----------
-        context: zmq.Context
-            ZMQ context used to make the various sockets necessary for communicating with the client.
-        url: str
-            Url where the RPCServer is opened. The url should include the port in the form
-            ``tcp://<ip>:<port>``.
-        name: str
-            Name of the RPCServer as given by the deviceregistry once registered
-        uuid: str
-            Unique identifier of this RPCServer given by the registry once registered..
-        peer_addr: str
-            Ip address of the client once connected.
-
         """
         super().__init__()
 
@@ -884,9 +1041,8 @@ class RPCServer:
 
         Returns
         -------
-        accepted_name: str
+        str
             Name of this device as accepted by the registry.
-
         """
         logger.debug(f"Register device {name} of type {type_} to {registry_url}")
         self._type = type_
@@ -908,11 +1064,11 @@ class RPCServer:
 
         return self.name
 
-
     @staticmethod
     def register_method_json(timeout: int | None = 10000):
         """
         Registers this method as remote callable procedure which will transmit its output via json.
+
         It is advised to only send basic types and containers as output (int, float, str, bool, list, tuple, dict, ...)
         Arguments are also serialized via json.
 
@@ -923,17 +1079,19 @@ class RPCServer:
 
         Returns
         -------
-        decorator: Callable[Callable[..., Any], Callable[..., Any]]
+        Callable[Callable[..., Any], Callable[..., Any]]
 
         """
         if inspect.isfunction(timeout):
             timeout._is_json_method = True
             timeout._timeout = 10000
             return timeout
+
         def _decorator(method: Callable[..., Any]):
             method._is_json_method = True
             method._timeout = timeout
             return method
+
         return _decorator
 
     @staticmethod
@@ -960,10 +1118,12 @@ class RPCServer:
             timeout._is_buffer_method = True
             timeout._timeout = 10000
             return timeout
-        def _decorator(method: Callable[..., tuple[memoryview|bytes, dict]]):
+
+        def _decorator(method: Callable[..., tuple[memoryview | bytes, dict]]):
             method._is_buffer_method = True
             method._timeout = timeout
             return method
+
         return _decorator
 
     def _send_signal(self, signal_name: str, *args):
@@ -1029,7 +1189,7 @@ class RPCServer:
         -----
         * The device is only unregistered when all three attributes
           ``self.name``, ``self.registry_addr`` and ``self.uuid`` evaluate to
-          ``True``.  If any of them is falsy, the function simply sets the
+          ``True``. If any of them is falsy, the function simply sets the
           stop flag and returns.
         * ``self._cleanup_state`` is updated after a successful unregister to
           avoid duplicate cleanup actions later in the object's lifecycle.
@@ -1059,7 +1219,7 @@ class RPCServer:
         The method enters a loop that repeatedly notifies the watchdog, checks the server's
         liveness, waits for a request, and dispatches the request based on its ``event`` field.
         Supported events include peer discovery, inventory retrieval, signal handling
-        initialization, method invocation, property access, and server shutdown.  Upon receiving
+        initialization, method invocation, property access, and server shutdown. Upon receiving
         a ``STOP_SERVER`` event the loop terminates, sockets are closed, and a log entry is
         written.
 
@@ -1072,7 +1232,7 @@ class RPCServer:
 
         Notes
         -----
-        * The private attribute ``_stop`` controls the loop termination.  It is set to
+        * The private attribute ``_stop`` controls the loop termination. It is set to
           ``True`` only when a ``STOP_SERVER`` request is processed.
         * ``_socket`` and ``_signal_socket`` are closed during cleanup; if either attribute is
           ``None`` the corresponding ``close`` call is skipped.
@@ -1127,7 +1287,7 @@ class RPCServer:
                 # If we have a request, we can at least try to answer with a generic error.
                 if isinstance(request, dict) and "event" in request:
                     self._send_reply(self._make_error_reply(exc, "serve_forever"))
-                break   # abort the loop – we are in an inconsistent state
+                break  # abort the loop - we are in an inconsistent state
 
         # cleanup
         if self._socket:
@@ -1144,7 +1304,7 @@ class RPCServer:
         Parameters
         ----------
         request
-            Mapping containing the keys ``"property"`` and ``"value"``.  The
+            Mapping containing the keys ``"property"`` and ``"value"``. The
             ``"property"`` entry specifies the name of the attribute to set on
             ``self`` and ``"value"`` is the value to assign.
 
@@ -1170,9 +1330,9 @@ class RPCServer:
         Retrieve the value of a named attribute from the instance.
 
         The function expects ``request`` to contain a ``"property"`` key whose
-        value is the name of the attribute to read.  It logs the operation, attempts
+        value is the name of the attribute to read. It logs the operation, attempts
         to obtain the attribute via :func:`getattr`, and returns a JSON‑serialisable
-        response.  Any exception raised while accessing the attribute is caught and
+        response. Any exception raised while accessing the attribute is caught and
         transformed into an error reply using :meth:`_make_error_reply`.
 
         Parameters
@@ -1186,7 +1346,7 @@ class RPCServer:
         dict
             A dictionary with the shape ``{"success": True, "value": <attr>}`` when
             the attribute is successfully retrieved, where ``<attr>`` is the value
-            of the requested property.  If an exception occurs, the dictionary is
+            of the requested property. If an exception occurs, the dictionary is
             the result of ``_make_error_reply`` and contains error information.
 
         Notes
@@ -1223,13 +1383,13 @@ class RPCServer:
         else:
             return {"success": True, "value": val}
 
-    def _handle_method_call(self, request: dict) -> tuple[dict|list[bytes], bool]:
+    def _handle_method_call(self, request: dict) -> tuple[dict | list[bytes], bool]:
         """
         Dispatch a JSON‑RPC request to the appropriate handler.
 
         The function extracts the ``method`` name and ``params`` from *request*,
         looks up the method in the internal registries and executes it using the
-        appropriate execution helper.  The return value indicates both the reply
+        appropriate execution helper. The return value indicates both the reply
         payload and whether the payload should be sent as a multipart (buffer)
         response.
 
@@ -1237,7 +1397,7 @@ class RPCServer:
         ----------
         request : dict
             Mapping that must contain the keys ``"method"`` (a ``str``) and
-            ``"params"`` (a ``dict`` mapping ``str`` to ``bytes``).  The method name
+            ``"params"`` (a ``dict`` mapping ``str`` to ``bytes``). The method name
             determines which registered handler is invoked.
 
         Returns
@@ -1247,7 +1407,7 @@ class RPCServer:
 
             * ``reply`` : ``dict`` or ``list[bytes]``
                 If the method is registered as a JSON handler, ``reply`` is a JSON‑
-                serialisable ``dict`` produced by :meth:`_exec_json`.  If the method
+                serialisable ``dict`` produced by :meth:`_exec_json`. If the method
                 is a buffer handler, ``reply`` is a ``list`` of ``bytes`` objects
                 returned by :meth:`_exec_buffer`.
 
@@ -1281,7 +1441,7 @@ class RPCServer:
         The method creates a ``REQ`` socket, connects it to the address and port
         specified in ``request``, stores the socket in ``self._cleanup_state`` for
         later cleanup, and registers a weak callback for each signal in
-        ``self._signals``.  The weak callback forwards the signal name and any
+        ``self._signals``. The weak callback forwards the signal name and any
         positional or keyword arguments to ``_send_signal`` without creating a
         reference cycle.
 
@@ -1387,7 +1547,7 @@ class RPCServer:
         return True
 
     # --------------------------------------------------------------------- #
-    #  Utility – error reporting
+    #  Utility - error reporting
     # --------------------------------------------------------------------- #
     @staticmethod
     def _make_error_reply(exc: Exception, context: str) -> dict:
@@ -1396,7 +1556,7 @@ class RPCServer:
 
         When an exception occurs during execution of a particular operation, this
         helper creates a response containing a failure flag, a string representation
-        of the exception, and a truncated traceback.  The traceback is limited to the
+        of the exception, and a truncated traceback. The traceback is limited to the
         most recent ten frames to keep the output concise.
 
         Parameters
@@ -1417,7 +1577,7 @@ class RPCServer:
         The function logs the error via the module‑level ``logger`` and prints the
         traceback to ``stderr`` to aid post‑mortem analysis.
         """
-        logger.error(f"Failed to execute '{context}' – {exc}")
+        logger.error(f"Failed to execute '{context}' - {exc}")
         tb = traceback.format_exc(limit=10)
         print(tb, file=sys.stderr)
         return {"success": False, "error": str(exc), "traceback": tb}

--- a/src/commons/plantimager/commons/RPC.py
+++ b/src/commons/plantimager/commons/RPC.py
@@ -1,3 +1,23 @@
+"""
+Remote Procedure Call (RPC) Framework.
+
+This module provides a lightweight RPC framework built on top of ZeroMQ.
+It supports method execution (both JSON-serializable and binary buffers),
+property proxying, and a publish-subscribe signaling mechanism.
+
+Classes
+-------
+NoResult
+    Represents an operation failure with error details.
+RPCSignal
+    Lightweight publish-subscribe signal implementation.
+RPCProperty
+    RPC-enabled property descriptor for proxying attribute access.
+RPCClient
+    Abstract client class for connecting to and interacting with an RPC server.
+RPCServer
+    Server class that exposes methods, properties, and signals over the network.
+"""
 import copy
 import inspect
 import json
@@ -23,9 +43,15 @@ from plantimager.commons.deviceregistry import register_device, unregister_devic
 from plantimager.commons.logging import create_logger
 from plantimager.commons.systemd import notify_watchdog
 
+__all__ = ["RPCClient", "RPCServer", "RPCProperty", "RPCSignal", "NoResult"]
+
 logger = create_logger("RPC")
 
 class RPCEvents(StrEnum):
+    """
+    Enumeration of valid RPC event types used for communication
+    between clients and servers.
+    """
     PROPERTY_GET = "PROPERTY_GET"
     PROPERTY_SET = "PROPERTY_SET"
     METHOD_CALL = "METHOD_CALL"
@@ -35,7 +61,7 @@ class RPCEvents(StrEnum):
     INIT_SIGNALS_HANDLING = "INIT_SIGNALS_HANDLING"
     EMIT_SIGNAL = "EMIT_SIGNAL"
 
-url_parser = re.compile(r"([a-zA-Z]*)://([a-zA-Z.0-9]*):?([0-9]*)")
+url_parser = re.compile(r"([a-zA-Z]*)://([a-zA-Z.0-9]*):?(\d*)")
 
 
 class NoResult:
@@ -359,8 +385,26 @@ class RPCProperty(property):
 
 class RPCSignalReceiver(Thread):
     """
-    A receiver thread for RPCClient to listen for and receive RPC Signals from the server and in turn
-    emit the same signals in the proxy.
+    Background thread that listens for and dispatches RPC signals from the server.
+
+    This thread binds a ZeroMQ `REP` socket to a random port and continuously
+    polls for incoming signal events. When a signal is received, it emits the
+    corresponding proxy signal on the client side.
+
+    Parameters
+    ----------
+    context : zmq.Context
+        The ZeroMQ context used to create the socket.
+    url : str
+        The base URL to bind the receiver socket (e.g., "tcp://127.0.0.1").
+    signals : dict of str to RPCSignal
+        A dictionary mapping signal names to their corresponding `RPCSignal`
+        instances on the client.
+
+    Attributes
+    ----------
+    port : int
+        The randomly selected port number this receiver is bound to.
     """
     def __init__(self, context: zmq.Context, url: str, signals: dict[str, RPCSignal]):
         super().__init__(name="RPCSignalReceiver")
@@ -372,6 +416,31 @@ class RPCSignalReceiver(Thread):
         self.port = self.socket.bind_to_random_port(url)
 
     def run(self):
+        """
+        Continuously processes incoming socket requests to emit signals.
+
+        This method runs an event loop that listens for incoming JSON requests via
+        a ZeroMQ socket. Requests are expected to contain an event key and
+        associated data such as signals and arguments. If a request matches the
+        expected event type (`RPCEvents.EMIT_SIGNAL`), a corresponding signal
+        is emitted. The loop runs until the `_stop_flag` is set to `True`.
+
+        Notes
+        -----
+        - If the `"blocking"` flag in the request is `True`, the signal emission is
+          performed before sending back a success response. Otherwise, the success
+          response is sent immediately, and the signal emission happens afterward.
+
+        Raises
+        ------
+        KeyError
+            If the incoming request JSON does not contain the required keys.
+        zmq.ZMQError
+            If there is an issue receiving or sending data via the ZeroMQ socket.
+        RuntimeError
+            If an error occurs while emitting a signal.
+
+        """
         try:
             while not self._stop_flag:
                 if self.socket.poll(100, zmq.POLLIN) == 0:
@@ -396,14 +465,34 @@ class RPCSignalReceiver(Thread):
         logger.debug(f"Stopping signal receiver {self}")
 
     def stop(self):
+        """
+        Signal the receiver thread to stop polling and shut down.
+        """
         self._stop_flag = True
 
 class RPCClient:
     """
-    Abstract class for RPC clients.
-    To use, create a class inheriting from the interface and this.
-    This new class must be decorated with `@RPCClient.register_interface`
+    Abstract base class for RPC clients.
 
+    This class sets up a ZeroMQ `REQ` socket to communicate with an `RPCServer`.
+    To use this, create a subclass that inherits from both a target interface
+    and this class, and decorate it with `@RPCClient.register_interface`.
+
+    Parameters
+    ----------
+    context : zmq.Context
+        The ZeroMQ context used for networking.
+    url : str
+        The URL of the target RPC server to connect to.
+
+    Attributes
+    ----------
+    own_address : str
+        The local IP address of the client.
+    peer_address : str
+        The IP address of the connected RPC server.
+    name : str
+        The designated name of the connected RPC server.
     """
 
     def __init__(self, context: zmq.Context, url: str):
@@ -473,6 +562,29 @@ class RPCClient:
 
     @classmethod
     def register_interface(cls, interface: type):
+        """
+        Class decorator to bind an interface to an RPCClient subclass.
+
+        This decorator inspects the provided `interface` and dynamically
+        proxies its methods and properties so that calls are forwarded
+        over the network to the RPC server.
+
+        Parameters
+        ----------
+        interface : type
+            The interface class defining the methods and properties to proxy.
+
+        Returns
+        -------
+        callable
+            A class decorator that applies the proxy logic.
+
+        Raises
+        ------
+        RuntimeError
+            If the decorated class does not inherit from both `interface`
+            and `RPCClient`.
+        """
         def _decorator(target_cls: type):
             if interface not in target_cls.__bases__ or cls not in target_cls.__bases__:
                 raise RuntimeError(f"{target_cls} must inherit from {interface} and {cls}.")
@@ -557,6 +669,28 @@ class RPCClient:
                 RPCClient._print_traceback_from_remote(traceback_)
 
     def execute(self, method_name: str, params: dict) -> tuple[bool, object]:
+        """
+        Execute a remote method on the RPC server.
+
+        Parameters
+        ----------
+        method_name : str
+            The name of the method to execute.
+        params : dict
+            A dictionary containing the `args` and `kwargs` for the method.
+
+        Returns
+        -------
+        tuple
+            A 2-tuple `(success, result)`. If `success` is True, `result`
+            contains the return value of the method. If False, `result`
+            is a tuple containing the `(error_message, traceback)`.
+
+        Raises
+        ------
+        TimeoutError
+            If the server does not respond within the configured timeout.
+        """
         package = {
             "event": RPCEvents.METHOD_CALL,
             "method": method_name,
@@ -590,6 +724,12 @@ class RPCClient:
         return False, (Warning(f"Unknown method {method_name}"), "")
 
     def stop_server(self):
+        """
+        Request the connected RPC server to shut down.
+
+        Sends a non-blocking `STOP_SERVER` event to the remote server.
+        If the server responds, it logs the reply.
+        """
         logger.info(f"Stopping server {self.url}")
         if self.socket.poll(timeout=1000, flags=zmq.POLLOUT) == 0:
             logger.info(f"Server {self.url} could not be joined (might already be dead)")

--- a/src/commons/plantimager/commons/RPC.py
+++ b/src/commons/plantimager/commons/RPC.py
@@ -1,12 +1,13 @@
 import copy
 import inspect
 import json
-import logging
 import random
 import re
 import socket
 import sys
 import traceback
+import logging
+import weakref
 from enum import StrEnum
 from functools import wraps, partial
 from threading import Thread
@@ -34,7 +35,7 @@ class RPCEvents(StrEnum):
     INIT_SIGNALS_HANDLING = "INIT_SIGNALS_HANDLING"
     EMIT_SIGNAL = "EMIT_SIGNAL"
 
-url_parser = re.compile("([a-zA-Z]*)://([a-zA-Z.0-9]*):?([0-9]*)")
+url_parser = re.compile(r"([a-zA-Z]*)://([a-zA-Z.0-9]*):?([0-9]*)")
 
 
 class NoResult:
@@ -65,14 +66,92 @@ class NoResult:
         return False
 
 class RPCSignal:
+    """RPCSignal
+    ---------
+    Lightweight publish‑subscribe signal implementation that stores either strong
+    or weak references to callables and invokes them with supplied arguments.
+
+    Instances are created with a variable number of *type specifications* that
+    describe the expected arguments for the signal.  These specifications are
+    stored unchanged in the :attr:`args` attribute; they are **not** validated at
+    runtime but may be used by callers for documentation or static checking.
+
+    Connections are added via :meth:`connect` and removed via :meth:`disconnect`.
+    When the signal is emitted with :meth:`emit`, each stored connection is called
+    in the order it was added.  Weak references that have been garbage‑collected
+    are silently ignored.
+
+    Parameters
+    ----------
+    *arg_types : tuple
+        Positional argument type specifications supplied at construction time.
+        The contents are opaque to the implementation – they are kept only for
+        external introspection.
+
+    Attributes
+    ----------
+    arg_types : tuple
+        The positional argument type specifications supplied to ``__init__``.
+        Callers may inspect this attribute for documentation or validation
+        purposes.
+
+    connections : list
+        Mutable list of connected callables or weak references.  Each entry is
+        either a callable object or a :class:`weakref.WeakMethod`.  The list is
+        modified by :meth:`connect` and :meth:`disconnect`.  Callables are
+        invoked in the order they were added when :meth:`emit` is called.
+
+    See Also
+    --------
+    weakref.WeakMethod : Standard library class used to store weak references to bound methods.
+    """
     def __init__(self, *arg_types):
+        """
+        Initialize a new ``RPCSignal`` instance.
+
+        Parameters
+        ----------
+        *arg_types : tuple
+            Positional argument type specifications.  The values are stored in
+            :attr:`args` but are otherwise not interpreted by the signal.
+
+        Notes
+        -----
+        ``arg_types`` can be any hashable objects (e.g., ``int``, ``str``,
+        ``numpy.ndarray``) that the user wishes to document as the expected
+        argument types for the signal.
+        """
         self.arg_types = arg_types
         self.connections = []
+        self.args = arg_types
+        self.connections: list[Callable | WeakMethod] = []
 
     def emit(self, *args):
+        """Emit the signal, invoking all connected callables.
+
+        Parameters
+        ----------
+        *args : tuple
+            Positional arguments that will be forwarded to each connected
+            callable.  The number and type of arguments should match the
+            specifications stored in :attr:`args`, but this is not enforced.
+
+        Notes
+        -----
+        - Weak references stored as :class:`weakref.WeakMethod` are dereferenced
+          before the call; if the underlying object has been garbage‑collected,
+          the entry is simply skipped.
+        - Any exception raised by a connected callable propagates to the caller
+          of :meth:`emit`.  The method does **not** catch or suppress errors.
+        """
         args = self.validate_args(*args, coerce=True)
         for conn in self.connections:
-            conn(*args)
+            if isinstance(conn, WeakMethod) and (func:=conn()):
+                # If the onnection is a WeakMethod and the method still lives
+                func(*args)
+            elif not isinstance(conn, weakref.WeakMethod):
+                # If this is not a weak method (ergo an actual method)
+                conn(*args)
 
     def validate_args(self, *args, coerce=False) -> tuple:
         """
@@ -126,29 +205,156 @@ class RPCSignal:
                 raise TypeError(f"Argument {i} of type {type(arg)} is not an instance of {arg_type}.")
         return tuple(new_args)
 
-    def connect(self, conn: Callable):
-        if not conn in self.connections:
+    def connect(self, conn: Callable | WeakMethod):
+        """Connect a callable (or weak reference) to the signal.
+
+        Parameters
+        ----------
+        conn : Callable or weakref.WeakMethod
+            The function, bound method, or weak reference that should be called
+            when the signal is emitted.
+
+        Raises
+        ------
+        TypeError
+            If ``conn`` is neither a callable nor a :class:`weakref.WeakMethod`.
+
+        Notes
+        -----
+        The same ``conn`` is added only once; duplicate connections are ignored.
+        """
+        if not isinstance(conn, (weakref.WeakMethod, Callable)):
+            raise TypeError("Expected callable or weakref.WeakMethod, got {}".format(type(conn)))
+        if conn not in self.connections:
             self.connections.append(conn)
 
     def disconnect(self, conn: Callable=None):
+        """Remove a previously connected callable or clear all connections.
+
+        Parameters
+        ----------
+        conn : Callable, optional
+            The specific callable or weak reference to remove.  If omitted (or
+            ``None``), *all* connections are cleared.
+
+        Raises
+        ------
+        ValueError
+            If ``conn`` is provided but is not present in :attr:`connections`.
+
+        Notes
+        -----
+        After a successful call, the target is no longer invoked by future
+        :meth:`emit` calls.
+        """
         if conn:
             self.connections.remove(conn)
         else:
             self.connections.clear()
 
 
-
 class RPCProperty(property):
     """
-    Declares a property for RPC usage. When the notify signal is emitted the proxy on the RPC Client is updated.
-    The signal provided in notify must be emitted in the setter when the property changes.
+    RPC-enabled property descriptor.
+
+    This subclass of :class:`property` adds optional notification support
+    via an :class:`RPCSignal`.  When a property created with ``RPCProperty``
+    is assigned a new value, the supplied ``notify`` signal (if provided)
+    can be emitted to inform remote listeners of the change.  The class is
+    typically used as a decorator on a getter function; the optional
+    ``notify`` argument is stored on the resulting property object and can
+    be accessed by custom setter implementations.
+    The setter must explicitly emit the ''notify'' signal if a change occurred.
+
+    Attributes
+    ----------
+    _notifier : RPCSignal or None
+        Signal that will be emitted when the property's value changes.
+        It is initialized from the ``notify`` argument of ``__init__`` and
+        may be ``None`` when no notification is required.
+    _auto_notify: bool
+        When True, when the setter of the property is called and the value is
+          modified, the _notifier is emitted.
     """
-    def __init__(self, fget=None, fset=None, fdel=None, doc=None, notify: RPCSignal = None):
+    def __init__(self, fget=None, fset=None, fdel=None, doc=None, notify: RPCSignal = None, auto_notify=False):
+        """
+        Initialize the property with optional RPC notification.
+
+        This subclass of ``property`` adds support for emitting an RPC signal
+        when the property value changes.  If ``auto_notify`` is ``True`` the
+        signal provided via ``notify`` is emitted automatically after a successful
+        set operation; otherwise the caller must trigger the notification
+        manually.
+
+        Parameters
+        ----------
+        fget : callable, optional
+            Getter function that receives the instance and returns the attribute
+            value.
+        fset : callable, optional
+            Setter function that receives the instance and the value to assign.
+        fdel : callable, optional
+            Deleter function that receives the instance and removes the attribute.
+        doc : str, optional
+            Documentation string for the property.
+        notify : RPCSignal, optional
+            RPC signal emitted when the property value is changed.
+        auto_notify : bool, default: ``False``
+            When ``True``, automatically emit ``notify`` after a successful set.
+
+        See Also
+        --------
+        property
+            Built‑in ``property`` class that this class extends.
+        """
         super().__init__(fget=fget, fset=fset, fdel=fdel, doc=doc)
-        self._notifier = notify
+        self._notifier: RPCSignal | None = notify
+        self._auto_notify: bool = auto_notify
 
     def __call__(self, func: Callable):
         return RPCProperty(fget=func, notify=self._notifier)
+
+    def __set__(self, obj, value):
+        """
+        Set the property on *obj* and emit the ``_notifier`` signal if the
+        observable value actually changes.
+
+        The logic is:
+        1. Retrieve the old value via the getter (if any).
+        2. Call the original setter.
+        3. Retrieve the new value via the getter.
+        4. If ``old != new`` and a notifier exists, emit the signal with the
+           new value.
+        """
+        # Step 1 – capture the old value (may be None if no getter)
+        old_val = None
+        if self._auto_notify and self.fget is not None:
+            try:
+                old_val = self.fget(obj)
+            except Exception:
+                # If the getter fails we simply ignore the old value;
+                # the change‑detection will fall back to always emit.
+                old_val = object()  # unique sentinel
+
+        # Step 2 – invoke the original setter (if any)
+        super().__set__(obj, value)
+
+        # Step 3 – capture the new value via the getter (if any)
+        new_val = None
+        if self._auto_notify and self.fget is not None:
+            try:
+                new_val = self.fget(obj)
+            except Exception:
+                new_val = object()  # unique sentinel
+
+        # Step 4 – emit if changed and a notifier is present
+        if self._auto_notify and self._notifier is not None and old_val != new_val:
+            try:
+                self._notifier.emit(new_val)
+            except Exception as exc:
+                # We never want a notification failure to break the setter.
+                logger.error(f"Failed to emit RPCProperty change signal: {exc}")
+
 
 
 class RPCSignalReceiver(Thread):
@@ -217,8 +423,8 @@ class RPCClient:
         self.socket.send_json({"event": RPCEvents.FIND_PEER_ADDRESS})
         reply = self.socket.recv_json()
         if not reply["success"]:
-            raise RuntimeError(f"FIND_PEER_ADDRESS failed")
-        protocol, ip_addr, port = url_parser.match(url).groups()
+            raise RuntimeError("FIND_PEER_ADDRESS failed")
+        _, ip_addr, _ = url_parser.match(url).groups()
         s = socket.create_connection((ip_addr, reply["port"]))
         self.own_address = s.getsockname()[0]
         self.peer_address = s.getpeername()[0]
@@ -253,7 +459,7 @@ class RPCClient:
                 self._signal_receiver.stop()
                 self._signal_receiver.join(2)
                 self._signal_receiver = None
-                raise RuntimeError(f"INIT_SIGNALS_HANDLING failed")
+                raise RuntimeError("INIT_SIGNALS_HANDLING failed")
             logger.info("Successfully initialized signal handling")
 
         def _finalizer(sock, receiver):
@@ -303,10 +509,14 @@ class RPCClient:
             err, trace = res
             logger.error(f"Failed to execute {method} on remote due to {err}")
             if logger.level == logging.DEBUG:
-                print("Traceback from remote --->", file=sys.stderr)
-                print(trace, file=sys.stderr, end="")
-                print("<------------", file=sys.stderr)
+                RPCClient._print_traceback_from_remote(trace)
             return NoResult(err, trace)
+
+    @staticmethod
+    def _print_traceback_from_remote(trace: str):
+        print("Traceback from remote --->", file=sys.stderr)
+        print(trace, file=sys.stderr, end="")
+        print("<------------", file=sys.stderr)
 
     def _property_getter_proxy(self, property_name: str) -> Any:
         package = {
@@ -325,9 +535,7 @@ class RPCClient:
             err, traceback_ = reply["error"], reply["traceback"]
             logger.error(f"Failed to get property {property_name} on remote due to {err}")
             if logger.level == logging.DEBUG:
-                print("Traceback from remote --->", file=sys.stderr)
-                print(traceback_, file=sys.stderr, end="")
-                print("<------------", file=sys.stderr)
+                RPCClient._print_traceback_from_remote(traceback_)
             return NoResult(err, traceback_)
 
     def _property_setter_proxy(self, value: Any, property_name: str) -> None:
@@ -346,11 +554,7 @@ class RPCClient:
             err, traceback_ = reply["error"], reply["traceback"]
             logger.error(f"Failed to get property {property_name} on remote due to {err}")
             if logger.level == logging.DEBUG:
-                print("Traceback from remote --->", file=sys.stderr)
-                print(traceback_, file=sys.stderr, end="")
-                print("<------------", file=sys.stderr)
-            return
-
+                RPCClient._print_traceback_from_remote(traceback_)
 
     def execute(self, method_name: str, params: dict) -> tuple[bool, object]:
         package = {
@@ -359,15 +563,15 @@ class RPCClient:
             "params": params,
         }
         if self.socket.poll(timeout=1000, flags=zmq.POLLOUT) == 0:
-            logger.warning(f"Proxy of {self._interface} at {self.url} did not respond")
-            return False, (Warning(f"Proxy of {self._interface} at {self.url} did not respond"), "")
+            logger.error(f"Proxy of {self._interface} at {self.url} did not respond")
+            raise TimeoutError(f"Proxy of {self._interface} at {self.url} did not respond")
         logger.debug(f"Executing {package}")
         self.socket.send_json(package, flags=zmq.NOBLOCK)
 
         if method_name in self._json_methods:
             if self.socket.poll(timeout=self._json_methods[method_name], flags=zmq.POLLIN) == 0:
-                logger.warning(f"Timeout reached, proxy of {self._interface} at {self.url} did not respond")
-                return False, (Warning(f"Proxy of {self._interface} at {self.url} did not respond"), "")
+                logger.error(f"Proxy of {self._interface} at {self.url} did not respond")
+                raise TimeoutError(f"Proxy of {self._interface} at {self.url} did not respond")
             reply =  self.socket.recv_json()
             if reply["success"]:
                 return True, reply["result"]
@@ -375,8 +579,8 @@ class RPCClient:
                 return False, (reply["error"], reply["traceback"])
         elif method_name in self._buffer_methods:
             if self.socket.poll(timeout=self._buffer_methods[method_name], flags=zmq.POLLIN) == 0:
-                logger.warning(f"Timeout reached, proxy of {self._interface} at {self.url} did not respond")
-                return False, (Warning(f"Proxy of {self._interface} at {self.url} did not respond"), "")
+                logger.error(f"Proxy of {self._interface} at {self.url} did not respond")
+                raise TimeoutError(f"Proxy of {self._interface} at {self.url} did not respond")
             reply_frames: list[zmq.Frame] = self.socket.recv_multipart(copy=False)
             buffer_info = json.loads(reply_frames[0].bytes)
             if "error" in buffer_info:
@@ -429,7 +633,7 @@ class RPCServer:
             Url where the RPCServer is opened.
         port: int
             Port where the RPCServer is opened.
-        name: int
+        name: str
             Name of the RPCServer as given by the deviceregistry once registered
         uuid: str
             Unique identifier of this RPCServer given by the registry once registered..
@@ -487,16 +691,15 @@ class RPCServer:
     def _bind_socket(self, url: str) -> tuple[zmq.Socket, int]:
         """Creates and binds the ZMQ REP socket."""
         socket: zmq.Socket[zmq.REP] = self.context.socket(zmq.REP)
-        protocol, ip_addr, port_str = url_parser.match(url).groups()
+        _, ip_addr, port_str = url_parser.match(url).groups()
 
         if port_str:
             port = int(port_str)
             try:
                 socket.bind(url)
-            except ZMQBindError as e:
-                logger.critical(f"Failed to bind to {url}")
-                logger.critical(e)
-                sys.exit(1)
+            except ZMQBindError:
+                logger.error(f"Failed to bind to {url}")
+                raise
         else:
             port = socket.bind_to_random_port(url, 10000, 12000)
 
@@ -513,9 +716,9 @@ class RPCServer:
             "signal_socket": None
         }
 
-        def _server_finalizer(state):
+        def _server_finalizer(state, signals):
             # This function does not capture 'self'
-            for signal in self._signals.values():
+            for signal in signals.values():
                 signal.disconnect()
             if state["uuid"] and state["registry_addr"]:
                 unregister_device(state["context"], state["uuid"], state["registry_addr"])
@@ -525,7 +728,7 @@ class RPCServer:
                 state["signal_socket"].close()
             logger.info("Server deleted")
 
-        finalize(self, _server_finalizer, self._cleanup_state)
+        finalize(self, _server_finalizer, self._cleanup_state, self._signals)
 
     def register_to_registry(self, type_: str, name: str, registry_url: str, overwrite=True) -> str:
         """
@@ -559,6 +762,8 @@ class RPCServer:
             name, registry_url,
             overwrite=overwrite,
         )
+        if not self.name:
+            logger.warning(f"Failed to register device {name} of type {type_} as {registry_url}")
         self.registry_addr = registry_url if self.name else ""
 
         # Update cleanup state so finalizer knows what to unregister
@@ -627,8 +832,8 @@ class RPCServer:
 
     def _send_signal(self, signal_name: str, *args):
         if not self._signal_socket:
-            logger.error(f"Signal socket not initialized")
-            raise RuntimeError(f"Signal socket not initialized")
+            logger.error("Signal socket not initialized")
+            raise RuntimeError("Signal socket not initialized")
         # Validate that we send a signal with arguments matching the expected types
         signal: RPCSignal = getattr(self, signal_name)
         signal.validate_args(*args)
@@ -643,39 +848,63 @@ class RPCServer:
         if not reply["success"]:
             logger.error(f"Signal {signal_name} failed with {reply}")
 
-    def _exec_json(self, method: Callable, params: dict):
+    def _exec_json(self, method: Callable, params: dict) -> dict:
         args = params["args"]
         kwargs = params["kwargs"]
         try:
-            result = method(self, *args, **kwargs)
+            result = method(*args, **kwargs)
         except Exception as e:
             logger.error(f"Failed to execute {method} due to {e}")
             traceback_str = traceback.format_exc(limit=10)
             print(traceback_str, file=sys.stderr)
             print(e, file=sys.stderr)
-            self._socket.send_json({"success": False, "error": str(e), "traceback": traceback_str})
+            return {"success": False, "error": str(e), "traceback": traceback_str}
         else:
-            self._socket.send_json({"success": True, "result": result})
+            return {"success": True, "result": result}
 
-    def _exec_buffer(self, method: Callable, params: dict):
+    def _exec_buffer(self, method: Callable, params: dict) -> list[bytes]:
         args = params["args"]
         kwargs = params["kwargs"]
         try:
-            buffer, buffer_info = method(self, *args, **kwargs)
+            buffer, buffer_info = method(*args, **kwargs)
         except Exception as e:
             logger.error(f"Failed to execute {method} due to {e}")
             traceback_str = traceback.format_exc(limit=10)
             print(traceback_str, file=sys.stderr)
             print(e, file=sys.stderr)
-            self._socket.send_multipart(
-                [json.dumps({"success": False, "error": str(e), "traceback": traceback_str}).encode("utf-8")],
-            )
+            return [json.dumps({"success": False, "error": str(e), "traceback": traceback_str}).encode("utf-8")]
         else:
-            self._socket.send_multipart(
-                [json.dumps(buffer_info).encode("utf-8"), buffer], copy=False
-            )
+            return [json.dumps(buffer_info).encode("utf-8"), buffer]
 
     def stop_server(self):
+        """
+        Stop the server and unregister the device if it has been registered.
+
+        The method sets the internal stop flag, optionally calls
+        :func:`unregister_device` to remove the device from a remote registry,
+        clears the identifying attributes (``name``, ``uuid``, ``registry_addr``),
+        and resets the corresponding entries in ``_cleanup_state`` to ``None``.
+        This prevents a second unregister attempt during cleanup.
+
+        Raises
+        ------
+        Exception
+            Propagates any exception raised by :func:`unregister_device`, e.g.
+            network errors or authentication failures.
+
+        Notes
+        -----
+        * The device is only unregistered when all three attributes
+          ``self.name``, ``self.registry_addr`` and ``self.uuid`` evaluate to
+          ``True``.  If any of them is falsy, the function simply sets the
+          stop flag and returns.
+        * ``self._cleanup_state`` is updated after a successful unregister to
+          avoid duplicate cleanup actions later in the object's lifecycle.
+
+        See Also
+        --------
+        unregister_device : Function that removes a device from the registry.
+        """
         self._stop = True
         if self.name and self.registry_addr and self.uuid:
             unregister_device(self.context, self.uuid, self.registry_addr)
@@ -691,116 +920,394 @@ class RPCServer:
 
     def serve_forever(self):
         """
-        Starts serving requests for this RPCServer.
+        Serve the RPC server indefinitely, handling incoming requests until a stop signal is
+        received.
+
+        The method enters a loop that repeatedly notifies the watchdog, checks the server's
+        liveness, waits for a request, and dispatches the request based on its ``event`` field.
+        Supported events include peer discovery, inventory retrieval, signal handling
+        initialization, method invocation, property access, and server shutdown.  Upon receiving
+        a ``STOP_SERVER`` event the loop terminates, sockets are closed, and a log entry is
+        written.
 
         If registered to the registry and the check_alive fails, exits the loop
 
         Returns
         -------
+        None
+            The server runs until it is stopped; no value is returned.
 
+        Notes
+        -----
+        * The private attribute ``_stop`` controls the loop termination.  It is set to
+          ``True`` only when a ``STOP_SERVER`` request is processed.
+        * ``_socket`` and ``_signal_socket`` are closed during cleanup; if either attribute is
+          ``None`` the corresponding ``close`` call is skipped.
+        * ``notify_watchdog`` and ``_alive_check`` are called on every iteration to maintain
+          server health monitoring.
+        * The method assumes that ``_wait_for_request`` returns a mapping with an ``event``
+          key; a falsy return value causes the loop to continue without processing.
+
+        See Also
+        --------
+        RPCEvents : Enum defining the possible request events.
+        _handle_find_peer_address, _handle_get_inventory, _handle_init_signal_handling,
+        _handle_method_call, _handle_property_get, _handle_property_set :
+            Private helper methods that implement the handling logic for each event type.
         """
         if self._dead:
             logger.error("RPCServer is in dead state. A new instance must be created.")
-            raise RuntimeError(f"RPCServer is in dead state. A new instance must be created.")
+            raise RuntimeError("RPCServer is in dead state. A new instance must be created.")
         self._stop = False
         while not self._stop:
+            if not self._alive_check():
+                logger.error(f"Check Alive failed. Registry at {self.registry_addr} "
+                             f"is unreachable or does not know this service.")
+                break
+
             notify_watchdog()
-            if self.registry_addr:
-                res = send_alive_check(self.context, self.uuid, self.registry_addr, self.alive_timeout)
-                if not res:
-                    # TODO: if res == False --> do something (reset?)
-                    logger.error(f"Check Alive failed. Registry at {self.registry_addr} "
-                                 f"is unreachable or does not know this service.")
-                    break
-            if self._socket.poll(1000, zmq.POLLIN) == 0:
+
+            request = self._wait_for_request()
+            if not request:
                 continue
-            request = self._socket.recv_json()
-            match request["event"]:
-                case RPCEvents.FIND_PEER_ADDRESS:
-                    logger.info("Finding peer address")
-                    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                    port = random.randint(49152, 65535)
-                    s.bind(("", port))  # may crash if unlucky
-                    s.listen(1)
-                    self._socket.send_json({"success": True, "port": port})
-                    c, addr_info = s.accept()
-                    self.peer_addr = addr_info[0]
-                    c.shutdown(socket.SHUT_RDWR)
-                    c.close()
-                    s.shutdown(socket.SHUT_RDWR)
-                    s.close()
-                    del s
-                    logger.info("Connected to peer at address: {}".format(self.peer_addr))
-                case RPCEvents.GET_INVENTORY:
-                    logger.info("Sending inventory")
-                    response = {
-                        "json_methods": {name: func._timeout for name, func in self._json_methods.items()},
-                        "buffer_methods": {name: func._timeout for name, func in self._buffer_methods.items()},
-                        "signals": list(self._signals.keys()),
-                        "properties": list(self._rpc_properties.keys()),
-                        "name": self.name,
-                    }
-                    logger.info(response)
-                    self._socket.send_json(response)
-                case RPCEvents.INIT_SIGNALS_HANDLING:
-                    logger.info("Initializing signal handling")
-                    address, port = request["address"], request["port"]
-                    self._signal_socket = self.context.socket(zmq.REQ)
-                    self._signal_socket.connect(f"tcp://{address}:{port}")
-                    self._cleanup_state["signal_socket"] = self._signal_socket
-                    weak_send_signal = WeakMethod(self._send_signal)
-                    for sig_name, sig in self._signals.items():
-                        sig.connect(lambda *args, sig_name=sig_name, **kwargs: weak_send_signal()(sig_name, *args, **kwargs))
-                    self._socket.send_json({"success": True})
-                    logger.info("Successfully initialized signal handling")
-                case RPCEvents.METHOD_CALL:
-                    method: str = request["method"]
-                    params: dict[str, bytes] = request["params"]
-                    logger.info(f"Executing {method} with params {params}")
-                    if method in self._json_methods:
-                        self._exec_json(self._json_methods[method], params)
-                    elif method in self._buffer_methods:
-                        self._exec_buffer(self._buffer_methods[method], params)
-                    else:
-                        logger.error(f"Method {method} not implemented")
-                        self._socket.send_json({"success": False, "error": f"Method {method} not implemented"})
-                case RPCEvents.PROPERTY_GET:
-                    prop_name: str = request["property"]
-                    logger.debug(f"Getting property {prop_name}")
-                    try:
-                        val = getattr(self, prop_name)
-                    except Exception as e:
-                        logger.error(f"Failed to execute 'get property' for property {prop_name}")
-                        traceback_str = traceback.format_exc(limit=10)
-                        print(traceback_str, file=sys.stderr)
-                        self._socket.send_json({"success": False, "error": str(e), "traceback": traceback_str})
-                    else:
-                        self._socket.send_json({
-                            "success": True, "value": val,
-                        })
-                case RPCEvents.PROPERTY_SET:
-                    prop_name: str = request["property"]
-                    val = request["value"]
-                    logger.debug(f"Setting property {prop_name} to {val}")
-                    try:
-                        setattr(self, prop_name, val)
-                    except Exception as e:
-                        logger.error(f"Failed to execute 'set property' for property {prop_name}")
-                        traceback_str = traceback.format_exc(limit=10)
-                        print(traceback_str, file=sys.stderr)
-                        self._socket.send_json({"success": False, "error": str(e), "traceback": traceback_str})
-                    else:
-                        self._socket.send_json({
-                            "success": True,
-                        })
-                case RPCEvents.STOP_SERVER:
-                    self._socket.send_json({"success": True})
-                    break
-        self._dead = True
-        for signal in self._signals.values():
-            signal.disconnect()
-        if self._signal_socket:
-            self._signal_socket.close()
+            try:
+                match request["event"]:
+                    case RPCEvents.FIND_PEER_ADDRESS:
+                        self._handle_find_peer_address()
+                    case RPCEvents.GET_INVENTORY:
+                        reply = self._handle_get_inventory()
+                        self._send_reply(reply)
+                    case RPCEvents.INIT_SIGNALS_HANDLING:
+                        reply = self._handle_init_signal_handling(request)
+                        self._send_reply(reply)
+                    case RPCEvents.METHOD_CALL:
+                        reply, use_multipart = self._handle_method_call(request)
+                        self._send_reply(reply, use_multipart)
+                    case RPCEvents.PROPERTY_GET:
+                        reply = self._handle_property_get(request)
+                        self._send_reply(reply)
+                    case RPCEvents.PROPERTY_SET:
+                        reply = self._handle_property_set(request)
+                        self._send_reply(reply)
+                    case RPCEvents.STOP_SERVER:
+                        self._socket.send_json({"success": True})
+                        self._stop = True
+            except Exception as exc:
+                logger.error(f"Unexpected error while handling request: {exc}")
+                # If we have a request, we can at least try to answer with a generic error.
+                if isinstance(request, dict) and "event" in request:
+                    self._send_reply(self._make_error_reply(exc, "serve_forever"))
+                break   # abort the loop – we are in an inconsistent state
+
+        # cleanup
         if self._socket:
             self._socket.close()
+        if self._signal_socket:
+            self._signal_socket.close()
+        self._dead = True
         logger.info("Server stopped")
+
+    def _handle_property_set(self, request: dict) -> dict:
+        """
+        Set an attribute on the instance based on a request dictionary.
+
+        Parameters
+        ----------
+        request
+            Mapping containing the keys ``"property"`` and ``"value"``.  The
+            ``"property"`` entry specifies the name of the attribute to set on
+            ``self`` and ``"value"`` is the value to assign.
+
+        Returns
+        -------
+        dict
+            ``{"success": True}`` if the attribute was set successfully, or an
+            error reply dictionary generated by :meth:`_make_error_reply` when an
+            exception occurs.
+        """
+        prop_name: str = request["property"]
+        val = request["value"]
+        logger.debug(f"Setting property {prop_name} to {val}")
+        try:
+            setattr(self, prop_name, val)
+        except Exception as e:
+            return self._make_error_reply(e, "set_property")
+        else:
+            return {"success": True}
+
+    def _handle_property_get(self, request: dict) -> dict:
+        """
+        Retrieve the value of a named attribute from the instance.
+
+        The function expects ``request`` to contain a ``"property"`` key whose
+        value is the name of the attribute to read.  It logs the operation, attempts
+        to obtain the attribute via :func:`getattr`, and returns a JSON‑serialisable
+        response.  Any exception raised while accessing the attribute is caught and
+        transformed into an error reply using :meth:`_make_error_reply`.
+
+        Parameters
+        ----------
+        request
+            Mapping that must include the key ``"property"`` identifying the
+            attribute whose value should be returned.
+
+        Returns
+        -------
+        dict
+            A dictionary with the shape ``{"success": True, "value": <attr>}`` when
+            the attribute is successfully retrieved, where ``<attr>`` is the value
+            of the requested property.  If an exception occurs, the dictionary is
+            the result of ``_make_error_reply`` and contains error information.
+
+        Notes
+        -----
+        * The method never propagates exceptions; all errors are captured and
+          reported via the error‑reply structure.
+        * The returned dictionary is intended to be JSON‑serialisable.
+
+        See Also
+        --------
+        _make_error_reply : Helper that formats a standardized error reply for
+            failed property accesses.
+
+        Examples
+        --------
+        >>> class Demo:
+        ...     def __init__(self):
+        ...         self.answer = 42
+        ...     def _make_error_reply(self, exc, op):
+        ...         return {"success": False, "error": str(exc), "operation": op}
+        ...     _handle_property_get = _handle_property_get
+        >>> d = Demo()
+        >>> d._handle_property_get({"property": "answer"})
+        {'success': True, 'value': 42}
+        >>> d._handle_property_get({"property": "missing"})
+        {'success': False, 'error': "...'"}  # error reply generated by _make_error_reply
+        """
+        prop_name: str = request["property"]
+        logger.debug(f"Getting property {prop_name}")
+        try:
+            val = getattr(self, prop_name)
+        except Exception as e:
+            return self._make_error_reply(e, "get_property")
+        else:
+            return {"success": True, "value": val}
+
+    def _handle_method_call(self, request: dict) -> tuple[dict|list[bytes], bool]:
+        """
+        Dispatch a JSON‑RPC request to the appropriate handler.
+
+        The function extracts the ``method`` name and ``params`` from *request*,
+        looks up the method in the internal registries and executes it using the
+        appropriate execution helper.  The return value indicates both the reply
+        payload and whether the payload should be sent as a multipart (buffer)
+        response.
+
+        Parameters
+        ----------
+        request : dict
+            Mapping that must contain the keys ``"method"`` (a ``str``) and
+            ``"params"`` (a ``dict`` mapping ``str`` to ``bytes``).  The method name
+            determines which registered handler is invoked.
+
+        Returns
+        -------
+        tuple
+            ``(reply, use_buffer)`` where:
+
+            * ``reply`` : ``dict`` or ``list[bytes]``
+                If the method is registered as a JSON handler, ``reply`` is a JSON‑
+                serialisable ``dict`` produced by :meth:`_exec_json`.  If the method
+                is a buffer handler, ``reply`` is a ``list`` of ``bytes`` objects
+                returned by :meth:`_exec_buffer`.
+
+            * ``use_buffer`` : ``bool``
+                ``True`` if the reply should be transmitted as a multipart/buffer
+                response, ``False`` for a regular JSON response.
+
+        See Also
+        --------
+        _exec_json : Execute a method that returns a JSON‑serialisable payload.
+        _exec_buffer : Execute a method that returns raw byte buffers.
+        """
+        method: str = request["method"]
+        params: dict[str, bytes] = request["params"]
+        logger.debug(f"Executing {method} with params {params}")
+        if method in self._json_methods:
+            reply = self._exec_json(getattr(self, method), params)
+            return reply, False  # use json
+        elif method in self._buffer_methods:
+            reply = self._exec_buffer(getattr(self, method), params)
+            return reply, True  # use multipart
+        else:
+            err = f"Method {method} not implemented"
+            logger.error(err)
+            return {"success": False, "error": err}, False
+
+    def _handle_init_signal_handling(self, request: dict) -> dict:
+        """
+        Initialize ZeroMQ signal handling based on the supplied request.
+
+        The method creates a ``REQ`` socket, connects it to the address and port
+        specified in ``request``, stores the socket in ``self._cleanup_state`` for
+        later cleanup, and registers a weak callback for each signal in
+        ``self._signals``.  The weak callback forwards the signal name and any
+        positional or keyword arguments to ``_send_signal`` without creating a
+        reference cycle.
+
+        Parameters
+        ----------
+        request
+            Mapping containing the keys ``'address'`` (str) and ``'port'`` (int)
+            that specify the endpoint to which the signal socket should connect.
+
+        Returns
+        -------
+        dict
+            ``{'success': True}`` indicating that the socket was successfully
+            created and all signal handlers were attached.
+
+        Raises
+        ------
+        KeyError
+            If ``request`` does not contain the required ``'address'`` or ``'port'``
+            entries.
+        """
+        logger.info("Initializing signal handling")
+        address, port = request["address"], request["port"]
+        self._signal_socket = self.context.socket(zmq.REQ)
+        self._signal_socket.connect(f"tcp://{address}:{port}")
+        self._cleanup_state["signal_socket"] = self._signal_socket
+        weak_send_signal = WeakMethod(self._send_signal)
+        for sig_name, sig in self._signals.items():
+            sig.connect(lambda *args, sig_name=sig_name, **kwargs: weak_send_signal()(sig_name, *args, **kwargs))
+        logger.info("Successfully initialized signal handling")
+        return {"success": True}
+
+    def _handle_get_inventory(self) -> dict:
+        """
+        Retrieve a dictionary describing the current RPC inventory.
+
+        Returns
+        -------
+        dict
+            Mapping with the following keys:
+
+            - ``json_methods``: ``dict`` mapping method names to their timeout values.
+            - ``buffer_methods``: ``dict`` mapping method names to their timeout values.
+            - ``signals``: ``list`` of registered signal names.
+            - ``properties``: ``list`` of RPCProperty names.
+            - ``name``: ``str`` representing the RPC object's identifier.
+        """
+        logger.info("Sending inventory")
+        response = {
+            "json_methods": {name: func._timeout for name, func in self._json_methods.items()},
+            "buffer_methods": {name: func._timeout for name, func in self._buffer_methods.items()},
+            "signals": list(self._signals.keys()),
+            "properties": list(self._rpc_properties.keys()),
+            "name": self.name,
+        }
+        logger.debug(response)
+        return response
+
+    def _handle_find_peer_address(self):
+        """
+        Find a free port, inform the peer, accept a connection, and record the peer's
+        address.
+        """
+        logger.info("Finding peer address")
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        port = random.randint(49152, 65535)
+
+        s.bind(("", port))  # may crash if unlucky
+        s.settimeout(20.0)  # s
+        s.listen(1)
+        self._send_reply({"success": True, "port": port})
+        try:
+            c, addr_info = s.accept()
+        except socket.timeout:
+            s.close()
+            logger.error("No peer connected to discovery socket after 20s – giving up.")
+            raise RuntimeError("Failed to find peer address")
+        self.peer_addr = addr_info[0]
+        c.shutdown(socket.SHUT_RDWR)
+        c.close()
+        s.shutdown(socket.SHUT_RDWR)
+        s.close()
+        del s
+        logger.info("Connected to peer at address: {}".format(self.peer_addr))
+
+    def _wait_for_request(self) -> dict | None:
+        if self._socket.poll(500, zmq.POLLIN) == 0:
+            return None
+        return self._socket.recv_json()
+
+    def _alive_check(self) -> bool:
+        if self.registry_addr:
+            return send_alive_check(self.context, self.uuid, self.registry_addr, self.alive_timeout)
+        return True
+    # --------------------------------------------------------------------- #
+    #  Utility – error reporting
+    # --------------------------------------------------------------------- #
+    @staticmethod
+    def _make_error_reply(exc: Exception, context: str) -> dict:
+        """
+        Generate a structured error reply dictionary for logging and debugging.
+
+        When an exception occurs during execution of a particular operation, this
+        helper creates a response containing a failure flag, a string representation
+        of the exception, and a truncated traceback.  The traceback is limited to the
+        most recent ten frames to keep the output concise.
+
+        Parameters
+        ----------
+        `exc`
+            The caught :class:`Exception` instance.
+        `context`
+            Description of the operation being performed when ``exc`` was raised.
+
+        Returns
+        -------
+        dict
+            Mapping with keys ``success`` (always ``False``), ``error`` containing the
+            exception message, and ``traceback`` containing the formatted traceback.
+
+        Notes
+        -----
+        The function logs the error via the module‑level ``logger`` and prints the
+        traceback to ``stderr`` to aid post‑mortem analysis.
+        """
+        logger.error(f"Failed to execute '{context}' – {exc}")
+        tb = traceback.format_exc(limit=10)
+        print(tb, file=sys.stderr)
+        return {"success": False, "error": str(exc), "traceback": tb}
+
+    def _send_reply(self, msg: dict | list[bytes], multipart=False) -> None:
+        """
+        Send a reply message through the internal ZeroMQ socket.
+
+        Parameters
+        ----------
+        msg
+            Message to be transmitted. If ``multipart`` is ``True`` the value
+            must be a ``list`` of ``bytes`` objects; otherwise a JSON‑serialisable
+            ``dict`` is expected.
+        multipart
+            When ``True`` use ``send_multipart``; otherwise use ``send_json``.
+            Defaults to ``False``.
+
+        Returns
+        -------
+        None
+            No value is returned; the message is sent directly on the socket.
+
+        Raises
+        ------
+        zmq.ZMQError
+            Propagated from the underlying ZeroMQ socket if the send operation
+            fails.
+        """
+        if multipart:
+            self._socket.send_multipart(msg, copy=False)
+        else:
+            self._socket.send_json(msg)

--- a/src/commons/plantimager/commons/RPC.py
+++ b/src/commons/plantimager/commons/RPC.py
@@ -21,7 +21,6 @@ RPCServer
 import copy
 import inspect
 import json
-import logging
 import random
 import re
 import socket
@@ -40,7 +39,7 @@ from decorator import decorate
 from zmq import ZMQBindError
 
 from plantimager.commons.utils import is_instance_of_generic, coerce_to_generic
-from plantimager.commons.deviceregistry import register_device, unregister_device, send_alive_check
+from plantimager.commons.deviceregistry import register_device, unregister_device, send_alive_check, AliveCheckState
 from plantimager.commons.logging import create_logger
 from plantimager.commons.systemd import notify_watchdog
 
@@ -1382,18 +1381,37 @@ class RPCServer:
         return self._socket.recv_json()
 
     def _alive_check(self) -> bool:
+        """
+        Perform a health check to determine if the service is alive and registered.
+
+        This method sends an alive check request to the registry server. If the registry
+        is unreachable or does not recognize the current service, appropriate actions
+        are taken, such as logging errors or warnings and optionally re-registering
+        the service. If no registry address is provided, then no health check is performed.
+
+        Returns
+        -------
+        bool
+            A boolean value indicating the service's health status:
+            ``True`` if the service is deemed alive or no registry address is provided.
+            ``False`` if the registry is unreachable.
+        """
         if self.registry_addr:
             res = send_alive_check(self.context, self.uuid, self.registry_addr, self.alive_timeout)
-            if res == "unreachable":
+            if res == AliveCheckState.UNREACHABLE:
                 logger.error(f"Check Alive failed. Registry at {self.registry_addr} "
                              f"is unreachable.")
+                # removing name and uuid because the server is not registered anymore
+                self.name = ""
+                self.uuid = ""
                 return False
-            elif res == "unregistered":
+            elif res == AliveCheckState.UNKNOWN:
                 logger.warning(f"Check Alive failed. Registry at {self.registry_addr} does not know this service."
                                f" Trying to reregister.")
                 self.register_to_registry(self._type, self.name, self.registry_addr, False)
                 return True
         return True
+
     # --------------------------------------------------------------------- #
     #  Utility – error reporting
     # --------------------------------------------------------------------- #

--- a/src/commons/plantimager/commons/RPC.py
+++ b/src/commons/plantimager/commons/RPC.py
@@ -21,10 +21,9 @@ RPCServer
 import copy
 import inspect
 import json
-import random
 import re
-import socket
 import sys
+import time
 import traceback
 import logging
 import weakref
@@ -57,7 +56,6 @@ class RPCEvents(StrEnum):
     METHOD_CALL = "METHOD_CALL"
     GET_INVENTORY = "GET_INVENTORY"
     STOP_SERVER = "STOP_SERVER"
-    FIND_PEER_ADDRESS = "FIND_PEER_ADDRESS"
     INIT_SIGNALS_HANDLING = "INIT_SIGNALS_HANDLING"
     EMIT_SIGNAL = "EMIT_SIGNAL"
 
@@ -409,11 +407,12 @@ class RPCSignalReceiver(Thread):
     def __init__(self, context: zmq.Context, url: str, signals: dict[str, RPCSignal]):
         super().__init__(name="RPCSignalReceiver")
         self.context = context
-        self.url = url
+        self.url = url  # now the server's PUB endpoint
         self._stop_flag = False
         self.signals = signals
-        self.socket: zmq.Socket = context.socket(zmq.REP)
-        self.port = self.socket.bind_to_random_port(url)
+        self.socket: zmq.Socket = context.socket(zmq.SUB)
+        self.socket.connect(url)
+        self.socket.setsockopt_string(zmq.SUBSCRIBE, "")  # subscribe to all
 
     def run(self):
         """
@@ -448,17 +447,11 @@ class RPCSignalReceiver(Thread):
                 request = self.socket.recv_json()
                 if request["event"] != RPCEvents.EMIT_SIGNAL:
                     logger.error(f"Expected event {RPCEvents.EMIT_SIGNAL}, got {request['event']} instead.")
-                    self.socket.send_json({"success": False})
                     continue
                 signal = request["signal"]
                 args = request["args"]
                 logger.debug(f"Emitting signal {signal} with args {args}")
-                if request["blocking"]:
-                    self.signals[signal].emit(*args)
-                    self.socket.send_json({"success": True})
-                else:
-                    self.socket.send_json({"success": True})
-                    self.signals[signal].emit(*args)
+                self.signals[signal].emit(*args)
         finally:
             self.socket.close()
             del self.socket
@@ -495,7 +488,7 @@ class RPCClient:
         The designated name of the connected RPC server.
     """
 
-    def __init__(self, context: zmq.Context, url: str):
+    def __init__(self, context: zmq.Context, url: str, timeout=1000):
         super().__init__()
         self.context: zmq.Context = context
         self.url: str = url
@@ -508,22 +501,14 @@ class RPCClient:
                 if isinstance(value, RPCSignal):
                     setattr(self, key, copy.deepcopy(value))
 
-        # Finding peer address (zmq abstract addresses so we use native sockets here)
-        self.socket.send_json({"event": RPCEvents.FIND_PEER_ADDRESS})
-        reply = self.socket.recv_json()
-        if not reply["success"]:
-            raise RuntimeError("FIND_PEER_ADDRESS failed")
-        _, ip_addr, _ = url_parser.match(url).groups()
-        s = socket.create_connection((ip_addr, reply["port"]))
-        self.own_address = s.getsockname()[0]
-        self.peer_address = s.getpeername()[0]
-        s.close()
-        logger.debug(f"Client at address {self.own_address} connected to server at {self.peer_address}")
-
         # Getting RPCServer inventory
+        logger.debug("--> Getting Inventory")
         self.socket.send_json({
             "event": RPCEvents.GET_INVENTORY
         })
+        if self.socket.poll(timeout=timeout, flags=zmq.POLLIN) == 0:
+            logger.error("Failed to get inventory. Server did not respond.")
+            raise TimeoutError("Failed to get inventory.")
         reply = self.socket.recv_json()
         logger.debug(f"Got inv: {reply}",)
         self._json_methods: dict[str, int|None] = reply["json_methods"]
@@ -531,25 +516,32 @@ class RPCClient:
         self._signals = {sig: getattr(self, sig) for sig in reply["signals"] if hasattr(self, sig)}
         self._properties: list = reply["properties"]
         self.name: str = reply["name"]
+        logger.debug("<-- Inventory Received")
 
         # If signals initiate
         self._signal_receiver = None
         if self._signals:
             logger.info("Initializing signal handling")
-            self._signal_receiver = RPCSignalReceiver(
-                context=self.context, url=f"tcp://{self.own_address}", signals=self._signals
-            )
-            self._signal_receiver.daemon = True  # FIXME: Should be False!
-            self._signal_receiver.start()
-            signal_port = self._signal_receiver.port
-            self.socket.send_json({"event": RPCEvents.INIT_SIGNALS_HANDLING, "address": self.own_address, "port": signal_port})
+            logger.debug("--> Initializing Signals Handling")
+            self.socket.send_json({"event": RPCEvents.INIT_SIGNALS_HANDLING})
+
+            if self.socket.poll(timeout=timeout, flags=zmq.POLLIN) == 0:
+                logger.error("Failed to initialize signals. Server did not respond.")
+                raise TimeoutError("Failed to initialize signals.")
             reply = self.socket.recv_json()
             if not reply["success"]:
-                self._signal_receiver.stop()
-                self._signal_receiver.join(2)
-                self._signal_receiver = None
                 raise RuntimeError("INIT_SIGNALS_HANDLING failed")
-            logger.info("Successfully initialized signal handling")
+
+            signal_port = reply["signal_port"]
+            proto, addr, _ = url_parser.search(self.url).groups()
+            self._signal_receiver = RPCSignalReceiver(
+                context=self.context,
+                url=f"{proto}://{addr}:{signal_port}",
+                signals=self._signals
+            )
+            self._signal_receiver.daemon = True
+            self._signal_receiver.start()
+            logger.info("<-- Successfully initialized signal handling")
 
         def _finalizer(sock, receiver):
             sock.close()
@@ -770,9 +762,8 @@ class RPCServer:
         context: zmq.Context
             ZMQ context used to make the various sockets necessary for communicating with the client.
         url: str
-            Url where the RPCServer is opened.
-        port: int
-            Port where the RPCServer is opened.
+            Url where the RPCServer is opened. The url should include the port in the form
+            ``tcp://<ip>:<port>``.
         name: str
             Name of the RPCServer as given by the deviceregistry once registered
         uuid: str
@@ -791,6 +782,7 @@ class RPCServer:
         self.name = ""
         self.registry_addr = ""
         self.peer_addr: str | None = None
+        self._unreachable_counter = 0
 
         # Containers for RPC members
         self._json_methods: dict[str, Callable] = {}
@@ -912,6 +904,8 @@ class RPCServer:
         self._cleanup_state["uuid"] = self.uuid
         self._cleanup_state["registry_addr"] = self.registry_addr
 
+        logger.info(f"Successfully registered device {name} of type {type_} to {registry_url}")
+
         return self.name
 
 
@@ -986,9 +980,6 @@ class RPCServer:
             "args": args,
             "blocking": False,
         })
-        reply = self._signal_socket.recv_json()
-        if not reply["success"]:
-            logger.error(f"Signal {signal_name} failed with {reply}")
 
     def _exec_json(self, method: Callable, params: dict) -> dict:
         args = params["args"]
@@ -1109,9 +1100,9 @@ class RPCServer:
             if not request:
                 continue
             try:
+                logger.debug(f"Received request: {request['event']}")
+                t0 = time.monotonic()
                 match request["event"]:
-                    case RPCEvents.FIND_PEER_ADDRESS:
-                        self._handle_find_peer_address()
                     case RPCEvents.GET_INVENTORY:
                         reply = self._handle_get_inventory()
                         self._send_reply(reply)
@@ -1130,6 +1121,7 @@ class RPCServer:
                     case RPCEvents.STOP_SERVER:
                         self._socket.send_json({"success": True})
                         self._stop = True
+                logger.debug(f"Event {request['event']} treated in {time.monotonic() - t0}s")
             except Exception as exc:
                 logger.error(f"Unexpected error while handling request: {exc}")
                 # If we have a request, we can at least try to answer with a generic error.
@@ -1312,15 +1304,18 @@ class RPCServer:
             entries.
         """
         logger.info("Initializing signal handling")
-        address, port = request["address"], request["port"]
-        self._signal_socket = self.context.socket(zmq.REQ)
-        self._signal_socket.connect(f"tcp://{address}:{port}")
-        self._cleanup_state["signal_socket"] = self._signal_socket
+        if self._signal_socket is None:
+            self._signal_socket = self.context.socket(zmq.PUB)
+            protocol, addr, _ = url_parser.search(self.url).groups()
+            self._signal_port = self._signal_socket.bind_to_random_port(f"{protocol}://{addr}")
+            self._cleanup_state["signal_socket"] = self._signal_socket
+
         weak_send_signal = WeakMethod(self._send_signal)
         for sig_name, sig in self._signals.items():
-            sig.connect(lambda *args, sig_name=sig_name, **kwargs: weak_send_signal()(sig_name, *args, **kwargs))
+            sig.connect(lambda *args, _sig_name=sig_name, **kwargs: weak_send_signal()(_sig_name, *args, **kwargs))
+
         logger.info("Successfully initialized signal handling")
-        return {"success": True}
+        return {"success": True, "signal_port": self._signal_port}
 
     def _handle_get_inventory(self) -> dict:
         """
@@ -1348,35 +1343,8 @@ class RPCServer:
         logger.debug(response)
         return response
 
-    def _handle_find_peer_address(self):
-        """
-        Find a free port, inform the peer, accept a connection, and record the peer's
-        address.
-        """
-        logger.info("Finding peer address")
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        port = random.randint(49152, 65535)
-
-        s.bind(("", port))  # may crash if unlucky
-        s.settimeout(20.0)  # s
-        s.listen(1)
-        self._send_reply({"success": True, "port": port})
-        try:
-            c, addr_info = s.accept()
-        except socket.timeout:
-            s.close()
-            logger.error("No peer connected to discovery socket after 20s – giving up.")
-            raise RuntimeError("Failed to find peer address")
-        self.peer_addr = addr_info[0]
-        c.shutdown(socket.SHUT_RDWR)
-        c.close()
-        s.shutdown(socket.SHUT_RDWR)
-        s.close()
-        del s
-        logger.info("Connected to peer at address: {}".format(self.peer_addr))
-
     def _wait_for_request(self) -> dict | None:
-        if self._socket.poll(500, zmq.POLLIN) == 0:
+        if self._socket.poll(2000, zmq.POLLIN) == 0:
             return None
         return self._socket.recv_json()
 
@@ -1399,17 +1367,23 @@ class RPCServer:
         if self.registry_addr:
             res = send_alive_check(self.context, self.uuid, self.registry_addr, self.alive_timeout)
             if res == AliveCheckState.UNREACHABLE:
-                logger.error(f"Check Alive failed. Registry at {self.registry_addr} "
-                             f"is unreachable.")
-                # removing name and uuid because the server is not registered anymore
-                self.name = ""
-                self.uuid = ""
-                return False
+                logger.warning("Check Alive failed. Got no response from registry.")
+                self._unreachable_counter += 1
             elif res == AliveCheckState.UNKNOWN:
                 logger.warning(f"Check Alive failed. Registry at {self.registry_addr} does not know this service."
                                f" Trying to reregister.")
                 self.register_to_registry(self._type, self.name, self.registry_addr, False)
+                self._unreachable_counter = 0
                 return True
+            else:
+                self._unreachable_counter = 0
+                return True
+            if self._unreachable_counter >= 3:
+                logger.error(f"Failed to reach registry {self._unreachable_counter} times.")
+                # removing name and uuid because the server is not registered anymore
+                self.name = ""
+                self.uuid = ""
+                return False
         return True
 
     # --------------------------------------------------------------------- #

--- a/src/commons/plantimager/commons/deviceregistry.py
+++ b/src/commons/plantimager/commons/deviceregistry.py
@@ -134,10 +134,12 @@ class DeviceRegistry(Thread):
                 for device_type, addr, name in self._callback_events_to_process["removed"]:
                     for callback in self._device_removed_callbacks:
                         callback(device_type, addr, name)
+                    logger.debug(f"Processed REMOVE callback for {device_type}, {addr}, {name}")
                 self._callback_events_to_process["removed"].clear()
                 for device_type, addr, name in self._callback_events_to_process["added"]:
                     for callback in self._new_device_callbacks:
                         callback(device_type, addr, name)
+                    logger.debug(f"Processed ADDED callback for {device_type}, {addr}, {name}")
                 self._callback_events_to_process["added"].clear()
 
                 # in order for the thread to stop properly, it must not block indefinitely while waiting for
@@ -147,7 +149,7 @@ class DeviceRegistry(Thread):
                 message = socket.recv_json()
                 event_type: str = message["event"]
                 payload: dict = message["payload"]
-                # logger.debug(f"Received event: {event_type}, {payload}")
+                logger.debug(f"Received event: {event_type}, {payload}")
                 match event_type:
                     case EventType.REGISTER:
                         device_type = payload["device_type"]

--- a/src/commons/plantimager/commons/deviceregistry.py
+++ b/src/commons/plantimager/commons/deviceregistry.py
@@ -216,7 +216,7 @@ class DeviceRegistry(Thread):
         This internal helper scans the ``device_health_timeout`` mapping for
         entries whose expiration timestamp is greater than the current Unix
         epoch time and removes the corresponding devices via
-        ``_remove_device_by_uuid``.  It is typically invoked by a maintenance
+        ``_remove_device_by_uuid``. It is typically invoked by a maintenance
         routine to keep the device registry up‑to‑date.
 
         Notes
@@ -248,11 +248,11 @@ class DeviceRegistry(Thread):
         Register a device while resolving address or name conflicts.
 
         This method checks the current device registry for existing entries that
-        share the same address or name as the proposed registration.  If a conflict
+        share the same address or name as the proposed registration. If a conflict
         is found and ``overwrite`` is ``False``, the conflicting device is removed
-        and a warning is logged.  When ``overwrite`` is ``True`` the method will
+        and a warning is logged. When ``overwrite`` is ``True`` the method will
         replace any device that matches either the address or the name with the
-        new registration.  After handling conflicts the device is added via
+        new registration. After handling conflicts the device is added via
         ``_add_device`` and the final stored name is returned.
 
         Parameters
@@ -430,10 +430,10 @@ def send_alive_check(context: zmq.Context, uuid: str, registry_url: str, alive_t
     """Check the liveness of a service with the registry.
 
     Send an ``EventType.CHECK_ALIVE`` request to the registry and wait for an
-    ``EventType.ACK`` reply.  The function opens a ``REQ`` socket on the provided
+    ``EventType.ACK`` reply. The function opens a ``REQ`` socket on the provided
     ZeroMQ ``context``, sends the payload containing ``uuid`` and ``alive_timeout``,
     and returns ``True`` only when an acknowledgement is received within the
-    socket poll timeout (5s).  Any other reply or the lack of a reply results in
+    socket poll timeout (5s). Any other reply or the lack of a reply results in
     ``False``.
 
     Parameters
@@ -446,8 +446,8 @@ def send_alive_check(context: zmq.Context, uuid: str, registry_url: str, alive_t
         URL of the registry (e.g., ``tcp://127.0.0.1:5555``) to which the request
         is sent.
     alive_timeout
-        Timeout (in seconds) that the service claims it will stay alive.  The
-        value is included in the request payload.  Defaults to ``ALIVE_TIMEOUT``.
+        Timeout (in seconds) that the service claims it will stay alive. The
+        value is included in the request payload. Defaults to ``ALIVE_TIMEOUT``.
 
     Returns
     -------
@@ -465,16 +465,16 @@ def send_alive_check(context: zmq.Context, uuid: str, registry_url: str, alive_t
     Notes
     -----
     * The socket is created inside a ``with`` block, guaranteeing that it is
-      closed when the block exits.  The explicit ``socket.close()`` calls are
+      closed when the block exits. The explicit ``socket.close()`` calls are
       retained for clarity but are not strictly required.
-    * The function uses a fixed poll timeout of 5 seconds; this value is not
+    * The function uses a fixed poll timeout of 5 seconds; this value is not
       configurable via the public API.
     * ``alive_timeout`` is merely echoed back to the registry and is not used by
       this function to enforce any timing constraints.
 
     See Also
     --------
-    `EventType` – enumeration of supported event types.
+    `EventType` - enumeration of supported event types.
     """
     with context.socket(zmq.REQ) as socket:
         socket: zmq.Socket

--- a/src/commons/plantimager/commons/deviceregistry.py
+++ b/src/commons/plantimager/commons/deviceregistry.py
@@ -299,7 +299,7 @@ class DeviceRegistry(Thread):
                 self._remove_device_by_name(name)
         return self._add_device(device_type, addr, proposed_name)
 
-    def _add_device(self, device_type: str, addr: str, proposed_name: str = None) -> str:
+    def _add_device(self, device_type: str, addr: str, proposed_name: str = None) -> tuple[str, str]:
         with self._lock:
             i = 0
             if not proposed_name:
@@ -418,8 +418,13 @@ def unregister_device(context: zmq.Context, uuid: str, registry_addr: str) -> bo
                 return True
             return False
 
+class AliveCheckState(StrEnum):
+    OK = "ok"
+    UNKNOWN = "unknown"
+    UNREACHABLE = "unreachable"
+
 def send_alive_check(context: zmq.Context, uuid: str, registry_url: str, alive_timeout: int=ALIVE_TIMEOUT) \
-        -> Literal["ok", "unreachable", "unknown"]:
+        -> AliveCheckState:
     """Check the liveness of a service with the registry.
 
     Send an ``EventType.CHECK_ALIVE`` request to the registry and wait for an
@@ -471,19 +476,19 @@ def send_alive_check(context: zmq.Context, uuid: str, registry_url: str, alive_t
     """
     with context.socket(zmq.REQ) as socket:
         socket: zmq.Socket
-        with socket.connect(registry_url):
-            socket.send_json({
-                "event": EventType.CHECK_ALIVE,
-                "payload": {
-                    "uuid": uuid,
-                    "alive_timeout": alive_timeout,
-                }
-            })
-            if socket.poll(5000, flags=zmq.POLLIN) == 0:
-                logger.debug(f"No answer from registry at address {registry_url}.")
-                return "unreachable"
-            reply = socket.recv_json()
-            event_type = reply["event"]
-            if event_type == EventType.ACK:
-                return "ok"
-            return "unknown"
+        socket.connect(registry_url)
+        socket.send_json({
+            "event": EventType.CHECK_ALIVE,
+            "payload": {
+                "uuid": uuid,
+                "alive_timeout": alive_timeout,
+            }
+        })
+        if socket.poll(5000, flags=zmq.POLLIN) == 0:
+            logger.debug(f"No answer from registry at address {registry_url}.")
+            return AliveCheckState.UNREACHABLE
+        reply = socket.recv_json()
+        event_type = reply["event"]
+        if event_type == EventType.ACK and reply.get("payload", {}).get("success", False):
+            return AliveCheckState.OK
+        return AliveCheckState.UNKNOWN

--- a/src/commons/plantimager/commons/logging.py
+++ b/src/commons/plantimager/commons/logging.py
@@ -10,11 +10,14 @@ tracking application events, errors, and performance metrics across different co
 
 import logging
 import sys
+import os
 
 import colorlog
 
+LOG_LEVEL = os.getenv("PI3_LOG_LEVEL", "INFO")
 
-def create_logger(name: str, level=logging.DEBUG) -> logging.Logger:
+
+def create_logger(name: str, level=LOG_LEVEL) -> logging.Logger:
     """Create a logger with the given name and specified logging level.
 
     Parameters
@@ -50,14 +53,16 @@ def create_logger(name: str, level=logging.DEBUG) -> logging.Logger:
     # Create a new logger instance with the specified name
     logger = logging.Logger(name)
     # Set the minimum logging level
+    if isinstance(level, str):
+        level = logging.getLevelNamesMapping().get(level, logging.INFO)
     logger.setLevel(level)
 
     # Create a LevelFormatter that uses different format strings based on log level
     # The log_color prefix enables colored output for each level
     formatter = colorlog.LevelFormatter(fmt={
-        logging.getLevelName(logging.DEBUG):    "{log_color} {name} {threadName} - {levelname}: {message} ({filename}:{lineno})",
-        logging.getLevelName(logging.INFO):     "{log_color} {name} {threadName} - {levelname}: {message}",
-        logging.getLevelName(logging.WARNING):  "{log_color} {name} {threadName} - {levelname}: {message} ({filename}:{lineno})",
+        logging.getLevelName(logging.DEBUG):    "[{log_color}] {name} {threadName} - {levelname}: {message} ({filename}:{lineno})",
+        logging.getLevelName(logging.INFO):     "[{log_color}] {name} {threadName} - {levelname}: {message}",
+        logging.getLevelName(logging.WARNING):  "[{log_color}] {name} {threadName} - {levelname}: {message} ({filename}:{lineno})",
         logging.getLevelName(logging.ERROR):    "[{log_color}] {name} {threadName} - {levelname}: {message} ({filename}:{lineno})",
         logging.getLevelName(logging.CRITICAL): "[{log_color}] {name} {threadName} - {levelname}: {message} ({filename}:{lineno})",
     }, style="{")

--- a/src/commons/plantimager/commons/utils.py
+++ b/src/commons/plantimager/commons/utils.py
@@ -1,12 +1,14 @@
+import collections.abc
+import types
+import typing
 from functools import wraps
 from time import time
-import typing
-import types
-import collections.abc
-from typing import Any, get_origin, get_args
+from typing import Any
+from typing import get_args
+from typing import get_origin
 
 
-def ttl_cache(maxsize: int=16, ttl: float=300):
+def ttl_cache(maxsize: int = 16, ttl: float = 300):
     """
     A decorator to cache the results of a function with a time-to-live (TTL) mechanism.
 
@@ -86,8 +88,10 @@ def ttl_cache(maxsize: int=16, ttl: float=300):
     >>> multiply(2, 3)
     6  # Cache was cleared, so the result is recomputed
     """
+
     def ttl_cache_inner(func):
         cache: dict = {}
+
         @wraps(func)
         def wrapper(*args, **kwargs):
             # clean every expired item
@@ -107,11 +111,14 @@ def ttl_cache(maxsize: int=16, ttl: float=300):
                     del cache[oldest]
                 cache[key] = (time(), val)
                 return val
+
         def clear_cache():
             """Clears the attached cache."""
             cache.clear()
+
         wrapper.clear_cache = clear_cache
         return wrapper
+
     return ttl_cache_inner
 
 
@@ -120,9 +127,9 @@ def coerce_to_generic(value: Any, generic_type: Any) -> Any:
     Coerce a value to a specified generic type or type hint.
 
     This utility attempts to convert ``value`` into the type described by
-    ``generic_type``.  It supports plain types, ``typing`` constructs such as
+    ``generic_type``. It supports plain types, ``typing`` constructs such as
     ``Union`` and ``Tuple``, as well as generic container types like ``list``,
-    ``dict`` and ``set``.  The function recurses as necessary to coerce nested
+    ``dict`` and ``set``. The function recurses as necessary to coerce nested
     structures and raises a ``TypeError`` when conversion is impossible.
 
     Parameters
@@ -130,7 +137,7 @@ def coerce_to_generic(value: Any, generic_type: Any) -> Any:
     value
         The object to be coerced.
     generic_type
-        The target type or type hint.  May be a concrete class, a ``typing``
+        The target type or type hint. May be a concrete class, a ``typing``
         generic (e.g., ``list[int]``), a union (e.g., ``int | str``), or
         ``typing.Any``.
 
@@ -157,20 +164,20 @@ def coerce_to_generic(value: Any, generic_type: Any) -> Any:
     -----
     The coercion logic proceeds through several ordered steps:
 
-    1. **Union handling** – If ``generic_type`` is a tuple of types, each
+    1. **Union handling** - If ``generic_type`` is a tuple of types, each
        member is tried in turn; the first successful conversion is returned.
        The same strategy is used for ``typing.Union`` and the ``|`` syntax
        introduced in Python 3.10.
 
-    2. **Any** – When ``generic_type`` is ``typing.Any`` the function returns
+    2. **Any** - When ``generic_type`` is ``typing.Any`` the function returns
        ``value`` unchanged.
 
-    3. **Simple types** – For non‑generic classes (e.g., ``int``, ``str``) the
+    3. **Simple types** - For non‑generic classes (e.g., ``int``, ``str``) the
        function first checks ``isinstance``; if the check fails it attempts to
        call the type as a constructor (``generic_type(value)``).
 
-    4. **Tuples** – ``tuple`` generics are distinguished between variadic
-       (``tuple[int, ...]``) and fixed‑size (``tuple[int, str]``) forms.  The
+    4. **Tuples** - ``tuple`` generics are distinguished between variadic
+       (``tuple[int, ...]``) and fixed‑size (``tuple[int, str]``) forms. The
        function validates iterability, then coerces each element according to
        the specified element type.
     """
@@ -248,15 +255,16 @@ def coerce_to_generic(value: Any, generic_type: Any) -> Any:
     except Exception as e:
         raise TypeError(f"Could not coerce {value!r} to {generic_type}: {e}")
 
+
 def is_instance_of_generic(value, generic_type):
     """
     Determine whether ``value`` conforms to a typing generic specification.
 
     This utility inspects ``generic_type`` using :func:`typing.get_origin` and
     :func:`typing.get_args` and recursively validates ``value`` against the
-    resolved origin and its type arguments.  It supports built‑in container
+    resolved origin and its type arguments. It supports built‑in container
     types (``list``, ``set``, ``tuple``, ``dict``) as well as user‑defined
-    generic classes.  When ``generic_type`` is a tuple, each element may be a
+    generic classes. When ``generic_type`` is a tuple, each element may be a
     distinct type specification; an ellipsis (``...``) as the last element
     denotes a variadic element type that applies to all items of the tuple.
 
@@ -266,7 +274,7 @@ def is_instance_of_generic(value, generic_type):
         The object whose type is being checked.
     generic_type : type or tuple of types
         A concrete type, a typing generic (e.g. ``list[int]``), or a tuple of
-        such specifications.  If a tuple is provided, the function returns
+        such specifications. If a tuple is provided, the function returns
         ``True`` when ``value`` matches **any** of the contained specifications.
 
     Returns
@@ -330,7 +338,7 @@ def is_instance_of_generic(value, generic_type):
     # For tuple check if it is a fixed size spec (Ellipsis in args otherwise)
     if issubclass(origin, tuple):
         # Validates tuple elements against variadic or fixed type spec
-        if args and args[-1] is  Ellipsis:
+        if args and args[-1] is Ellipsis:
             return all(
                 is_instance_of_generic(val, tuple(args[:-1])) for val in value
             )

--- a/src/controller/plantimager/controller/AppBridge.py
+++ b/src/controller/plantimager/controller/AppBridge.py
@@ -10,7 +10,7 @@ from threading import Thread
 from plantimager.commons import deviceregistry
 from plantimager.commons.logging import create_logger
 from plantimager.commons.systemd import is_systemd_process
-from plantimager.controller.camera.CameraBridge import CameraBridge
+from plantimager.controller.camera.CameraBridge import CameraBridge, DummyCameraBridge
 from plantimager.controller.scanner.rpc_controller import RPCControllerServer
 from plantimager.controller.scanner.scanner import Scanner
 
@@ -64,7 +64,7 @@ class AppBridge(QObject):
         self.device_list: list[str] = []
         self.device_bridges: list[CameraBridge] = []
 
-        self._currentCamera = CameraBridge("", "", self.context)
+        self._currentCamera = DummyCameraBridge(self)
         self._scanner = Scanner()
 
         self._controller_server = RPCControllerServer(self.context, "tcp://localhost:14567", self._scanner)
@@ -126,7 +126,7 @@ class AppBridge(QObject):
 
         Meant to be connected to the signal `_registryNewDevice` as a QueuedConnection.
         """
-        logger.debug(f"New device for {addr}: {device_type}, {name}")
+        logger.debug(f"--> New device for {addr}: {device_type}, {name}")
         if device_type.lower() == "camera":
             logger.debug("New camera, creating bridge and adding to scanner.")
             new_bridge = CameraBridge(name, addr, self.context)
@@ -137,6 +137,7 @@ class AppBridge(QObject):
             if not self._currentCamera:
                 self.currentCamera = new_bridge
                 self.currentCameraChanged.emit(new_bridge)
+        logger.debug(f"<-- New device for {addr}: {device_type}, {name}")
 
     def _new_device_callback(self, device_type: str, addr: str, name: str):
         """
@@ -164,15 +165,17 @@ class AppBridge(QObject):
 
         Meant to be connected to the signal `_registryRemoveDevice` as a QueuedConnection.
         """
+        logger.debug(f"--> Removing device {name} of type {device_type} at {addr}")
         idx = self.device_list.index(name)
         device = self.device_bridges[idx]
         self.scanner.remove_camera(device.camera)
         del self.device_list[idx]
         del self.device_bridges[idx]
         if len(self.device_bridges) == 0:
-            self._currentCamera = CameraBridge("", "", self.context)
+            self._currentCamera = DummyCameraBridge(self)
             self.currentCameraChanged.emit(self._currentCamera)
         self.deviceListChanged.emit()
+        logger.debug(f"<-- Removing device {name} of type {device_type} at {addr}")
 
     def _remove_device_callback(self, device_type: str, addr: str, name: str):
         """

--- a/src/controller/plantimager/controller/AppBridge.py
+++ b/src/controller/plantimager/controller/AppBridge.py
@@ -1,16 +1,22 @@
 import subprocess
+from threading import Thread
 from weakref import finalize
 
 import zmq
-from PySide6.QtCore import QObject, QThread, Signal, Slot, QAbstractListModel, Property, QModelIndex, Qt, QStringListModel
-from PySide6.QtQml import QmlSingleton, QmlElement
-
-from threading import Thread
+from PySide6.QtCore import Property
+from PySide6.QtCore import QObject
+from PySide6.QtCore import QStringListModel
+from PySide6.QtCore import Qt
+from PySide6.QtCore import Signal
+from PySide6.QtCore import Slot
+from PySide6.QtQml import QmlElement
+from PySide6.QtQml import QmlSingleton
 
 from plantimager.commons import deviceregistry
 from plantimager.commons.logging import create_logger
 from plantimager.commons.systemd import is_systemd_process
-from plantimager.controller.camera.CameraBridge import CameraBridge, DummyCameraBridge
+from plantimager.controller.camera.CameraBridge import CameraBridge
+from plantimager.controller.camera.CameraBridge import DummyCameraBridge
 from plantimager.controller.scanner.rpc_controller import RPCControllerServer
 from plantimager.controller.scanner.scanner import Scanner
 
@@ -18,7 +24,8 @@ logger = create_logger("AppBridge")
 
 QML_IMPORT_NAME = "PlantImagerApp"
 QML_IMPORT_MAJOR_VERSION = 1
-QML_IMPORT_MINOR_VERSION = 0 # Optional
+QML_IMPORT_MINOR_VERSION = 0  # Optional
+
 
 @QmlElement
 @QmlSingleton
@@ -40,7 +47,6 @@ class AppBridge(QObject):
         List of device names.
     device_bridges: list[CameraBridge]
         List of camera bridges.
-
     """
 
     currentCameraChanged = Signal(QObject)
@@ -84,11 +90,13 @@ class AppBridge(QObject):
             controller_thread.join()
             context.term()
             logger.debug("AppBridge finalized")
+
         finalize(self, finalizer, self.registry, self._controller_server, self._controller_thread, self.context)
 
     @Property(QObject, notify=currentCameraChanged)
     def currentCamera(self) -> CameraBridge:
         return self._currentCamera
+
     @currentCamera.setter
     def currentCamera(self, camera: CameraBridge):
         if self._currentCamera is not camera:
@@ -103,6 +111,7 @@ class AppBridge(QObject):
     def getCameraBridgeAtIndex(self, index: int) -> CameraBridge:
         """
         (Slot) Returns the camera bridge at a given index.
+
         Parameters
         ----------
         index: int
@@ -144,6 +153,7 @@ class AppBridge(QObject):
         Callback called by deviceregistry when a new device is registered.
 
         This must return immediately as to avoid deadlocks.
+
         Parameters
         ----------
         device_type
@@ -216,4 +226,5 @@ class AppBridge(QObject):
 
     @Property(bool, constant=True)
     def is_systemd_service(self) -> bool:
-        return subprocess.run(["systemctl", "--user", "is-active", "plant-imager-app.service", "-q"]).returncode == 0 and is_systemd_process()
+        return subprocess.run(["systemctl", "--user", "is-active", "plant-imager-app.service",
+                               "-q"]).returncode == 0 and is_systemd_process()

--- a/src/controller/plantimager/controller/PlantImagerApp/Controls/CameraView.qml
+++ b/src/controller/plantimager/controller/PlantImagerApp/Controls/CameraView.qml
@@ -81,7 +81,7 @@ Control {
                 format: "mpegts"
                 videoSink: videoOutput.videoSink
                 autoPlay: false
-                rotation: bridge.rotation
+                rotation: bridge ? bridge.rotation : 0
                 Component.onCompleted: {
                     componentComplete()
                 }
@@ -140,6 +140,7 @@ Control {
             autoExclusive: true
             checkable: true
             checked: false
+            enabled: bridge ? bridge.status === "connected" : false
             onClicked: {
                 bridge.mode = "VIDEO"
             }
@@ -154,7 +155,7 @@ Control {
             id: focus_highlight_button
             Layout.fillWidth: true
             Layout.fillHeight: true
-            //enabled: bridge
+            enabled: bridge ? bridge.status !== "invalid" : false
             text: bridge ? bridge.displayMode : ""
             onClicked: {
                 if(bridge) {
@@ -171,6 +172,7 @@ Control {
             autoExclusive: true
             checkable: true
             checked: false
+            enabled: bridge ? bridge.status === "connected" : false
 
             onClicked: {
                 bridge.mode = "STILL"
@@ -185,6 +187,7 @@ Control {
         Button {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            enabled: bridge ? bridge.status === "connected" : false
             text: "Take Picture"
             onClicked: {
                 bridge.getLoresImage()

--- a/src/controller/plantimager/controller/camera/CameraBridge.py
+++ b/src/controller/plantimager/controller/camera/CameraBridge.py
@@ -1,21 +1,26 @@
 import os.path
-import sys
 from enum import StrEnum
 from typing import Literal
 from weakref import finalize
 
 import zmq
-from PySide6.QtCore import QObject, Signal, Slot, Property
-from PySide6.QtQml import QmlElement, QmlUncreatable
+from PySide6.QtCore import Property
+from PySide6.QtCore import QObject
+from PySide6.QtCore import Signal
+from PySide6.QtCore import Slot
+from PySide6.QtQml import QmlElement
+from PySide6.QtQml import QmlUncreatable
 
 from plantimager.commons.logging import create_logger
-from plantimager.controller.camera.PiCameraComm import PiCameraComm, CameraStates
 from plantimager.controller.ImageProvider import imageProvider
+from plantimager.controller.camera.PiCameraComm import CameraStates
+from plantimager.controller.camera.PiCameraComm import PiCameraComm
 
 QML_IMPORT_NAME = "PlantImagerApp.Camera"
 QML_IMPORT_MAJOR_VERSION = 1
 
 logger = create_logger("CameraBridge")
+
 
 class StatusClass(StrEnum):
     OK = "ok"
@@ -24,6 +29,7 @@ class StatusClass(StrEnum):
     INACTIVE = "inactive"
     WAITING = "waiting"
 
+
 STATE_TO_CLASS = {
     CameraStates.DISCONNECTED: StatusClass.INACTIVE,
     CameraStates.INVALID: StatusClass.ERROR,
@@ -31,12 +37,14 @@ STATE_TO_CLASS = {
     CameraStates.WAITING: StatusClass.WAITING,
 }
 
+
 class DisplayMode(StrEnum):
     NORMAL = "normal"
     FOCUS = "focus"
     ZOOMED = "zoomed"
     ZOOMED_FOCUS = "zoomed-focus"
     ALIGN = "align"
+
 
 @QmlElement
 @QmlUncreatable("Camera bridge cannot be created from QML")
@@ -79,7 +87,7 @@ class CameraBridge(QObject):
         self.camera.videoUrlChanged.connect(self._videoUrlChanged)
         self.camera.stateChanged.connect(self.statusChanged)
 
-        self._mode: Literal["VIDEO", "STILL"]  = self.camera.mode
+        self._mode: Literal["VIDEO", "STILL"] = self.camera.mode
         self._rotation: int = self.camera.rotation
         self.camera.rotationChanged.connect(self._camera_rotation_change_handler)
         self._i = 0
@@ -87,8 +95,8 @@ class CameraBridge(QObject):
         def _finalizer(camera):
             del camera
             logger.debug(f"bridge {self._name} finalized")
-        finalize(self, _finalizer, self.camera)
 
+        finalize(self, _finalizer, self.camera)
 
     @Slot()
     def getImage(self):
@@ -105,6 +113,7 @@ class CameraBridge(QObject):
     @Property(str, notify=modeChanged)
     def mode(self):
         return self._mode
+
     @mode.setter
     def mode(self, value: Literal["VIDEO", "STILL"]):
         if self._mode != value and self.camera:
@@ -126,7 +135,7 @@ class CameraBridge(QObject):
         imageProvider.addImageFromBuffer(f"{self._name}-{self._i}", buffer, buffer_info)
         self._image_source = f"image://provider/{self._name}-{self._i}"
         self.imageSourceChanged.emit(self._image_source)
-        self._i  = (self._i + 1) % 2
+        self._i = (self._i + 1) % 2
 
     @Property(str, notify=nameChanged)
     def name(self) -> str:
@@ -174,6 +183,7 @@ class CameraBridge(QObject):
     @Property(int, notify=rotationChanged)
     def rotation(self) -> int:
         return self._rotation
+
     @rotation.setter
     def rotation(self, value: int):
         if self.camera:
@@ -182,6 +192,7 @@ class CameraBridge(QObject):
     @Property(str, notify=displayModeChanged)
     def displayMode(self) -> DisplayMode:
         return self._displayMode
+
     @displayMode.setter
     def displayMode(self, value: DisplayMode):
         if self._displayMode != value:

--- a/src/controller/plantimager/controller/camera/CameraBridge.py
+++ b/src/controller/plantimager/controller/camera/CameraBridge.py
@@ -9,7 +9,7 @@ from PySide6.QtCore import QObject, Signal, Slot, Property
 from PySide6.QtQml import QmlElement, QmlUncreatable
 
 from plantimager.commons.logging import create_logger
-from plantimager.controller.camera.PiCameraComm import PiCameraComm
+from plantimager.controller.camera.PiCameraComm import PiCameraComm, CameraStates
 from plantimager.controller.ImageProvider import imageProvider
 
 QML_IMPORT_NAME = "PlantImagerApp.Camera"
@@ -24,17 +24,11 @@ class StatusClass(StrEnum):
     INACTIVE = "inactive"
     WAITING = "waiting"
 
-class States(StrEnum):
-    DISCONNECTED = "disconnected"
-    INVALID = "invalid"
-    CONNECTED = "connected"
-    WAITING = "waiting"
-
 STATE_TO_CLASS = {
-    States.DISCONNECTED: StatusClass.INACTIVE,
-    States.INVALID: StatusClass.ERROR,
-    States.CONNECTED: StatusClass.OK,
-    States.WAITING: StatusClass.WAITING,
+    CameraStates.DISCONNECTED: StatusClass.INACTIVE,
+    CameraStates.INVALID: StatusClass.ERROR,
+    CameraStates.CONNECTED: StatusClass.OK,
+    CameraStates.WAITING: StatusClass.WAITING,
 }
 
 class DisplayMode(StrEnum):
@@ -76,39 +70,25 @@ class CameraBridge(QObject):
         self._image_source = ""
         self._displayMode = DisplayMode.NORMAL
         if name == "empty" or address == "":
-            self._status = States.INVALID
-            self.camera = None
-            self._mode = "STILL"
-            self._rotation = 0
-            return
-        self._status = States.DISCONNECTED
+            raise RuntimeError("Empty camera bridge cannot be created.")
         self.statusChanged.connect(lambda state: self.statusClassChanged.emit(STATE_TO_CLASS[state]))
 
         self.camera = PiCameraComm(context, address)
         self.camera.imageReady.connect(self._newImage)
         self.camera.modeChanged.connect(self._modeChanged)
         self.camera.videoUrlChanged.connect(self._videoUrlChanged)
+        self.camera.stateChanged.connect(self.statusChanged)
+
         self._mode: Literal["VIDEO", "STILL"]  = self.camera.mode
         self._rotation: int = self.camera.rotation
         self.camera.rotationChanged.connect(self._camera_rotation_change_handler)
-        self._status = States.CONNECTED
         self._i = 0
-
-        self.camera.waitingForResponseChanged.connect(self._camera_waiting_for_response_changed)
 
         def _finalizer(camera):
             del camera
             logger.debug(f"bridge {self._name} finalized")
         finalize(self, _finalizer, self.camera)
 
-    @Slot(bool)
-    def _camera_waiting_for_response_changed(self, waiting: bool):
-        if waiting:
-            self._status = States.WAITING
-            self.statusChanged.emit(self._status)
-        else:
-            self._status = States.CONNECTED
-            self.statusChanged.emit(self._status)
 
     @Slot()
     def getImage(self):
@@ -141,7 +121,6 @@ class CameraBridge(QObject):
         self.videoSourceChanged.emit(self._video_source)
         if videoUrl: self.videoReady.emit()
 
-
     @Slot(memoryview, dict)
     def _newImage(self, buffer: memoryview, buffer_info: dict):
         imageProvider.addImageFromBuffer(f"{self._name}-{self._i}", buffer, buffer_info)
@@ -159,11 +138,11 @@ class CameraBridge(QObject):
 
     @Property(str, notify=statusChanged)
     def status(self) -> str:
-        return self._status
+        return self.camera.state
 
     @Property(str, notify=statusClassChanged)
     def statusClass(self) -> str:
-        return STATE_TO_CLASS[self._status]
+        return STATE_TO_CLASS[self.status]
 
     @Property(str, notify=videoSourceChanged)
     def videoSource(self) -> str:
@@ -222,3 +201,23 @@ class CameraBridge(QObject):
             self.displayMode = DisplayMode.ALIGN
         elif self._displayMode == DisplayMode.ALIGN:
             self.displayMode = DisplayMode.NORMAL
+
+
+@QmlElement
+@QmlUncreatable("Camera bridge cannot be created from QML")
+class DummyCameraBridge(CameraBridge):
+    """
+    DummyCameraBridge class serves as a placeholder when no camera is available.
+    """
+    statusChanged = Signal(str)
+
+    def __init__(self, parent: QObject):
+        self._status = CameraStates.INVALID
+        self.camera = None
+        self._mode = "STILL"
+        self._rotation = 0
+        self._displayMode = DisplayMode.NORMAL
+
+    @Property(str, notify=statusChanged)
+    def status(self) -> str:
+        return self._status

--- a/src/controller/plantimager/controller/camera/PiCameraComm.py
+++ b/src/controller/plantimager/controller/camera/PiCameraComm.py
@@ -1,19 +1,31 @@
+import weakref
 from concurrent.futures import ThreadPoolExecutor, Future
-from typing import Literal
+from enum import StrEnum
+from typing import Literal, Any
 from weakref import finalize
+from contextlib import contextmanager
 
 import zmq
 from PySide6.QtCore import QObject, Slot, Signal, Property
 
 from plantimager.commons.RPC import RPCClient
 from plantimager.commons.cameradevice import Camera
+from plantimager.commons.logging import create_logger
+
+logger = create_logger(__name__)
+
+class CameraStates(StrEnum):
+    DISCONNECTED = "disconnected"
+    INVALID = "invalid"
+    CONNECTED = "connected"
+    WAITING = "waiting"
 
 
 @RPCClient.register_interface(Camera)
 class PiCameraProxy(Camera, RPCClient):
     def __init__(self, context: zmq.Context, url: str):
         Camera.__init__(self)
-        RPCClient.__init__(self, context, url)
+        RPCClient.__init__(self, context, url, timeout=5000)
 
 
 class PiCameraComm(QObject):
@@ -32,34 +44,90 @@ class PiCameraComm(QObject):
     resolutionChanged = Signal(int, int)
     encodingChanged = Signal(str)
     configChanged = Signal(dict)
-    waitingForResponseChanged = Signal(bool)
+    stateChanged = Signal(str)
 
     def __init__(self, context: zmq.Context, url: str, parent: QObject = None):
         QObject.__init__(self, parent)
-        self.camera = PiCameraProxy(context, url)
+        self._state = CameraStates.DISCONNECTED
+        self._context = context
+        self.url = url
         self._thread_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"{self.__class__.__name__}Thread")
-        self.camera.modeChanged.connect(lambda mode: self.modeChanged.emit(mode))
-        self.camera.videoUrlChanged.connect(lambda u: self.videoUrlChanged.emit(u))
-        self.camera.rotationChanged.connect(lambda rot: self.rotationChanged.emit(rot))
-        self.camera.resolutionChanged.connect(lambda res: self.resolutionChanged.emit(*res))
-        self.camera.encodingChanged.connect(lambda e: self.encodingChanged.emit(e))
-        self.camera.configChanged.connect(lambda c: self.configChanged.emit(c))
-        self._waiting_for_response = False
+        self._camera: PiCameraProxy | None = None
+        self._attempt_connection()
 
         def _finalizer(pool, camera):
-            pool.shutdown(wait=True)
-            camera.stop_server()
-        finalize(self, _finalizer, self._thread_pool, self.camera)
+            pool.shutdown(wait=False)
+            if camera:
+                camera.stop_server()
+        finalize(self, _finalizer, self._thread_pool, self._camera)
+    
+    def _attempt_connection(self):
+        weak_self = weakref.ref(self)
+        def _attempt_connection_callback(ft: Future[PiCameraProxy]):
+            s = weak_self()
+            if s is None:
+                return
+            if ft.exception() is None:
+                s._camera = ft.result()
+                s._camera.modeChanged.connect(lambda mode: (obj := weak_self()) and obj.modeChanged.emit(mode))
+                s._camera.videoUrlChanged.connect(lambda u: (obj := weak_self()) and obj.videoUrlChanged.emit(u))
+                s._camera.rotationChanged.connect(lambda rot: (obj := weak_self()) and obj.rotationChanged.emit(rot))
+                s._camera.resolutionChanged.connect(
+                    lambda res: (obj := weak_self()) and obj.resolutionChanged.emit(*res))
+                s._camera.encodingChanged.connect(lambda e: (obj := weak_self()) and obj.encodingChanged.emit(e))
+                s._camera.configChanged.connect(lambda c: (obj := weak_self()) and obj.configChanged.emit(c))
+                s._set_state(CameraStates.CONNECTED)
+            else:
+                #logger.warning("Connection failed")
+                s._attempt_connection()
+        future = self._thread_pool.submit(lambda :PiCameraProxy(self._context, self.url))
+        future.add_done_callback(_attempt_connection_callback)
+
+    @contextmanager
+    def camera(self):
+        current_state = self.state
+        try:
+            if current_state == CameraStates.DISCONNECTED:
+                yield None
+            else:
+                self._set_state(CameraStates.WAITING)
+                yield self._camera
+        except TimeoutError:
+            self._set_state(CameraStates.DISCONNECTED)
+            self._attempt_connection()
+        else:
+            self._set_state(current_state)
+
+    def _set_attr_async(self, attr_name: str, value: Any) -> None:
+        def callback(ft_: Future):
+            if ft_.exception():
+                self._set_state(CameraStates.DISCONNECTED)
+                self._attempt_connection()
+            else:
+                self._set_state(CameraStates.CONNECTED)
+        if self._camera and self.state == CameraStates.CONNECTED:
+            self._set_state(CameraStates.WAITING)
+            ft = self._thread_pool.submit(lambda: setattr(self._camera, attr_name, value))
+            ft.add_done_callback(callback)
+        
+    @Property(str, notify=stateChanged)
+    def state(self) -> CameraStates:
+        return self._state
+    def _set_state(self, state: CameraStates):
+        if state != self._state and state in CameraStates:
+            self._state = state
+            self.stateChanged.emit(state.value)
 
     @Slot(bool, result=Future)
-    def getImage(self, lores=False) -> Future[tuple[memoryview, dict]]:
+    def getImage(self, lores=False) -> Future[tuple[memoryview, dict]] | None:
         """
         Submits a call to camera.get_image() and returns a future representing the pending result.
         When camera.get_image() returns and the result is available, the signal imageReady is emitted.
 
         Returns
         -------
-        future : Future[tuple[memoryview, dict]]
+        future or None : Future[tuple[memoryview, dict]] or None
+            returns None when the camera is unavailable
 
         """
         def _callback(ft_: Future):
@@ -67,92 +135,71 @@ class PiCameraComm(QObject):
             res = ft_.result()
             if res:
                 buffer, buffer_info = res
-                self.waiting_for_response = False
+                self._set_state(CameraStates.CONNECTED)
                 self.imageReady.emit(buffer, buffer_info)
-        self.waiting_for_response = True
-        ft = self._thread_pool.submit(self.camera.get_image, lores=lores)
-        ft.add_done_callback(_callback)
-        return ft
+        if self._camera and self.state == CameraStates.CONNECTED:
+            self._set_state(CameraStates.WAITING)
+            ft = self._thread_pool.submit(self._camera.get_image, lores=lores)
+            ft.add_done_callback(_callback)
+            return ft
+        else:
+            return None
 
     @Property(str, notify=modeChanged)
     def mode(self) -> Literal["VIDEO", "STILL"]:
-        self.waiting_for_response = True
-        val = self.camera.mode
-        self.waiting_for_response = False
+        with self.camera() as camera:
+            val = camera.mode if camera is not None else "STILL"
         return val
     @mode.setter
     def mode(self, value: Literal["VIDEO", "STILL"]):
-        self.waiting_for_response = True
-        ft = self._thread_pool.submit(lambda : setattr(self.camera, "mode", value))
-        ft.add_done_callback(lambda *arg: setattr(self, "waiting_for_response", False))
+        self._set_attr_async("mode", value)
 
     @Property(str, notify=videoUrlChanged)
     def videoUrl(self):
-        self.waiting_for_response = True
-        val = self.camera.video_url
-        self.waiting_for_response = False
+        with self.camera() as camera:
+            val = camera.video_url if camera is not None else ""
         return val
 
     @Property(int, notify=rotationChanged)
     def rotation(self):
-        self.waiting_for_response = True
-        val = self.camera.rotation
-        self.waiting_for_response = False
+        with self.camera() as camera:
+            val = camera.rotation if camera is not None else 0
         return val
     @rotation.setter
     def rotation(self, value: int):
-        self.waiting_for_response = True
-        ft = self._thread_pool.submit(lambda : setattr(self.camera, "rotation", value))
-        ft.add_done_callback(lambda *arg: setattr(self, "waiting_for_response", False))
+        self._set_attr_async("rotation", value)
 
     @Property(str)
     def name(self):
-        self.waiting_for_response = True
-        val = self.camera.name
-        self.waiting_for_response = False
+        with self.camera() as camera:
+            val = camera.name if camera is not None else ""
         return val
 
     @Property(int, notify=resolutionChanged)
     def resolution(self):
-        self.waiting_for_response = True
-        val = self.camera.resolution
-        self.waiting_for_response = False
+        with self.camera() as camera:
+            val = camera.resolution if camera else (-1, -1)
         return val
     @resolution.setter
     def resolution(self, value: tuple[int, int]):
-        self.waiting_for_response = True
-        ft = self._thread_pool.submit(lambda : setattr(self.camera, "resolution", value))
-        ft.add_done_callback(lambda *arg: setattr(self, "waiting_for_response", False))
+        self._set_attr_async("resolution", value)
 
     @Property(int, notify=encodingChanged)
     def encoding(self):
-        self.waiting_for_response = True
-        val = self.camera.encoding
-        self.waiting_for_response = False
+        with self.camera() as camera:
+            val = camera.encoding if camera else ""
         return val
     @encoding.setter
     def encoding(self, value: tuple[int, int]):
-        self.waiting_for_response = True
-        ft = self._thread_pool.submit(lambda : setattr(self.camera, "encoding", value))
-        ft.add_done_callback(lambda *arg: setattr(self, "waiting_for_response", False))
+        self._set_attr_async("encoding", value)
 
     @Property(int, notify=configChanged)
     def config(self):
-        self.waiting_for_response = True
-        val = self.camera.config
-        self.waiting_for_response = False
+        with self.camera() as camera:
+            val = camera.config if camera else {}
         return val
     @config.setter
     def config(self, value: tuple[int, int]):
-        self.waiting_for_response = True
-        ft = self._thread_pool.submit(lambda : setattr(self.camera, "config", value))
-        ft.add_done_callback(lambda *arg: setattr(self, "waiting_for_response", False))
+        self._set_attr_async("config", value)
 
-    @Property(bool, notify=waitingForResponseChanged)
-    def waiting_for_response(self):
-        return self._waiting_for_response
-    @waiting_for_response.setter
-    def waiting_for_response(self, value: bool):
-        if value != self._waiting_for_response:
-            self._waiting_for_response = value
-            self.waitingForResponseChanged.emit(self._waiting_for_response)
+

--- a/src/controller/plantimager/controller/camera/PiCameraComm.py
+++ b/src/controller/plantimager/controller/camera/PiCameraComm.py
@@ -1,18 +1,24 @@
 import weakref
-from concurrent.futures import ThreadPoolExecutor, Future
-from enum import StrEnum
-from typing import Literal, Any
-from weakref import finalize
+from concurrent.futures import Future
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from enum import StrEnum
+from typing import Any
+from typing import Literal
+from weakref import finalize
 
 import zmq
-from PySide6.QtCore import QObject, Slot, Signal, Property
+from PySide6.QtCore import Property
+from PySide6.QtCore import QObject
+from PySide6.QtCore import Signal
+from PySide6.QtCore import Slot
 
 from plantimager.commons.RPC import RPCClient
 from plantimager.commons.cameradevice import Camera
 from plantimager.commons.logging import create_logger
 
 logger = create_logger(__name__)
+
 
 class CameraStates(StrEnum):
     DISCONNECTED = "disconnected"
@@ -59,10 +65,12 @@ class PiCameraComm(QObject):
             pool.shutdown(wait=False)
             if camera:
                 camera.stop_server()
+
         finalize(self, _finalizer, self._thread_pool, self._camera)
-    
+
     def _attempt_connection(self):
         weak_self = weakref.ref(self)
+
         def _attempt_connection_callback(ft: Future[PiCameraProxy]):
             s = weak_self()
             if s is None:
@@ -78,9 +86,10 @@ class PiCameraComm(QObject):
                 s._camera.configChanged.connect(lambda c: (obj := weak_self()) and obj.configChanged.emit(c))
                 s._set_state(CameraStates.CONNECTED)
             else:
-                #logger.warning("Connection failed")
+                # logger.warning("Connection failed")
                 s._attempt_connection()
-        future = self._thread_pool.submit(lambda :PiCameraProxy(self._context, self.url))
+
+        future = self._thread_pool.submit(lambda: PiCameraProxy(self._context, self.url))
         future.add_done_callback(_attempt_connection_callback)
 
     @contextmanager
@@ -105,14 +114,16 @@ class PiCameraComm(QObject):
                 self._attempt_connection()
             else:
                 self._set_state(CameraStates.CONNECTED)
+
         if self._camera and self.state == CameraStates.CONNECTED:
             self._set_state(CameraStates.WAITING)
             ft = self._thread_pool.submit(lambda: setattr(self._camera, attr_name, value))
             ft.add_done_callback(callback)
-        
+
     @Property(str, notify=stateChanged)
     def state(self) -> CameraStates:
         return self._state
+
     def _set_state(self, state: CameraStates):
         if state != self._state and state in CameraStates:
             self._state = state
@@ -126,10 +137,10 @@ class PiCameraComm(QObject):
 
         Returns
         -------
-        future or None : Future[tuple[memoryview, dict]] or None
-            returns None when the camera is unavailable
-
+        Future[tuple[memoryview, dict]] or None
+            Returns ``None`` when the camera is unavailable
         """
+
         def _callback(ft_: Future):
             if ft_.cancelled(): return
             res = ft_.result()
@@ -137,6 +148,7 @@ class PiCameraComm(QObject):
                 buffer, buffer_info = res
                 self._set_state(CameraStates.CONNECTED)
                 self.imageReady.emit(buffer, buffer_info)
+
         if self._camera and self.state == CameraStates.CONNECTED:
             self._set_state(CameraStates.WAITING)
             ft = self._thread_pool.submit(self._camera.get_image, lores=lores)
@@ -150,6 +162,7 @@ class PiCameraComm(QObject):
         with self.camera() as camera:
             val = camera.mode if camera is not None else "STILL"
         return val
+
     @mode.setter
     def mode(self, value: Literal["VIDEO", "STILL"]):
         self._set_attr_async("mode", value)
@@ -165,6 +178,7 @@ class PiCameraComm(QObject):
         with self.camera() as camera:
             val = camera.rotation if camera is not None else 0
         return val
+
     @rotation.setter
     def rotation(self, value: int):
         self._set_attr_async("rotation", value)
@@ -180,6 +194,7 @@ class PiCameraComm(QObject):
         with self.camera() as camera:
             val = camera.resolution if camera else (-1, -1)
         return val
+
     @resolution.setter
     def resolution(self, value: tuple[int, int]):
         self._set_attr_async("resolution", value)
@@ -189,6 +204,7 @@ class PiCameraComm(QObject):
         with self.camera() as camera:
             val = camera.encoding if camera else ""
         return val
+
     @encoding.setter
     def encoding(self, value: tuple[int, int]):
         self._set_attr_async("encoding", value)
@@ -198,8 +214,7 @@ class PiCameraComm(QObject):
         with self.camera() as camera:
             val = camera.config if camera else {}
         return val
+
     @config.setter
     def config(self, value: tuple[int, int]):
         self._set_attr_async("config", value)
-
-

--- a/src/webui/plantimager/webui/controller_proxy.py
+++ b/src/webui/plantimager/webui/controller_proxy.py
@@ -116,7 +116,7 @@ class RPCController(ControllerDevice, RPCClient):
         url : str
             The URL to connect to for RPC communication.
         """
-        RPCClient.__init__(self, context, url)
+        RPCClient.__init__(self, context, url, timeout=120_000)
         self.__class__._instance = self
 
     @classmethod

--- a/src/webui/plantimager/webui/controller_proxy.py
+++ b/src/webui/plantimager/webui/controller_proxy.py
@@ -44,13 +44,6 @@ class RPCController(ControllerDevice, RPCClient):
     Only one instance of this class can exist at a time, and it can be accessed through
     the `instance` class method.
 
-    Parameters
-    ----------
-    context : zmq.Context
-        The ZeroMQ context to use for communication.
-    url : str
-        The URL to connect to for RPC communication.
-
     Attributes
     ----------
     _instance : RPCController or None

--- a/test/test_RPC_registry.py
+++ b/test/test_RPC_registry.py
@@ -36,6 +36,9 @@ class TestInterface:
     def get_blob(self) -> Tuple[memoryview, dict]:
         pass
 
+    def echo_hanging(self, message: str) -> str:
+        pass
+
 
 class TestDevice(TestInterface, RPCServer):
     """Concrete Server Implementation."""
@@ -47,6 +50,11 @@ class TestDevice(TestInterface, RPCServer):
 
     @RPCServer.register_method_json(timeout=1000)
     def echo(self, message: str) -> str:
+        return f"Echo: {message}"
+
+    @RPCServer.register_method_json(timeout=100)
+    def echo_hanging(self, message: str) -> str:
+        time.sleep(2)
         return f"Echo: {message}"
 
     @RPCServer.register_method_buffer(timeout=1000)
@@ -324,9 +332,7 @@ class TestRobustness(BaseRPCTest):
     def test_server_recovers_registration_after_registry_restart(self):
         """
         Scenario: Registry crashes and restarts.
-        Expected: Server's 'alive check' fails, detects registry loss, and re-registers itself.
-        Current Behavior: Server logs error but does not re-register.
-        Required Fix: Implement re-registration logic in RPCServer.serve_forever loop when alive_check fails.
+        Expected: Server's 'alive check' fails, detects registry loss, and exits, entering a dead state.
         """
         # 1. Verify initial registration
         self.assertIn("robust_dev", self.registry.get_devices())
@@ -341,40 +347,22 @@ class TestRobustness(BaseRPCTest):
         self.assertNotIn("robust_dev", self.registry.get_devices())
 
         # 4. Wait for Server to heartbeat (alive_timeout=2s in TestDevice)
-        time.sleep(3)
+        self.server_thread.join()
+        self.registry.stop()
+        self.registry.join()
 
-        # 5. Check if Server re-registered
-        # This will fail because RPCServer currently just logs "Check Alive failed"
-        devices = self.registry.get_devices()
-        self.assertIn("robust_dev", devices, "Server failed to re-register after registry restart")
+        # 5. Check if Server stopped
+        self.assertFalse(self.server_thread.is_alive(), "Server's 'alive check' fails, detects registration loss, and exits.")
 
     def test_client_timeout_handling_on_call(self):
         """
         Scenario: Server hangs indefinitely during a method call.
         Expected: Client raises a TimeoutError or specific exception, not just returning False/NoResult.
-        Current Behavior: Client returns False or NoResult object which suppresses the exception context.
-        Required Fix: Client execute() should raise exceptions for timeouts to allow proper try/except flow.
         """
-        # Mock a server freeze
-        original_method = self.server.echo
-
-        def hanging_method(self, msg):
-            print("A")
-            time.sleep(5)  # Longer than client timeout (1s)
-            print("B")
-            return original_method(msg)
-        self.server.echo = hanging_method
-
-        # Monkey patch the instance method
-        # Note: This is tricky with RPCServer structure, essentially we simulate a timeout
-        # by making the client timeout shorter than server processing.
-
         client = TestClientProxy(self.context, self.server_url)
-        # We need to manually lower the timeout map in the client for this specific test
-        client._json_methods['echo'] = 100  # 100ms timeout
 
         with self.assertRaises(TimeoutError, msg="Client did not raise TimeoutError on server hang"):
-            rep = client.echo("Hello")
+            rep = client.echo_hanging("Hello")
             print(rep)
         del client
 

--- a/test/test_RPC_registry.py
+++ b/test/test_RPC_registry.py
@@ -1,0 +1,412 @@
+import gc
+import unittest
+import threading
+import time
+import zmq
+import logging
+import uuid
+from typing import Tuple, Literal
+
+# Adjust imports based on your actual package structure
+from plantimager.commons.RPC import (
+    RPCClient, RPCServer, RPCSignal, RPCProperty, NoResult, RPCEvents
+)
+from plantimager.commons.deviceregistry import (
+    DeviceRegistry, EventType, ALIVE_TIMEOUT
+)
+
+
+# --- Test Fixtures & Interfaces ---
+
+class TestInterface:
+    """Interface definition for testing RPC."""
+    signal_something_happened = RPCSignal(str)
+
+    @RPCProperty
+    def test_prop(self) -> int:
+        pass
+
+    @test_prop.setter
+    def test_prop(self, value: int):
+        pass
+
+    def echo(self, message: str) -> str:
+        pass
+
+    def get_blob(self) -> Tuple[memoryview, dict]:
+        pass
+
+
+class TestDevice(TestInterface, RPCServer):
+    """Concrete Server Implementation."""
+
+    def __init__(self, context: zmq.Context, url: str):
+        # Reduced timeout for faster tests
+        RPCServer.__init__(self, context, url, alive_timeout=2)
+        self._prop_val = 0
+
+    @RPCServer.register_method_json(timeout=1000)
+    def echo(self, message: str) -> str:
+        return f"Echo: {message}"
+
+    @RPCServer.register_method_buffer(timeout=1000)
+    def get_blob(self) -> Tuple[memoryview, dict]:
+        data = b"\xde\xad\xbe\xef"
+        return memoryview(data), {"size": 4, "type": "raw"}
+
+    @RPCProperty(notify=TestInterface.signal_something_happened)
+    def test_prop(self) -> int:
+        return self._prop_val
+
+    @test_prop.setter
+    def test_prop(self, value: int):
+        if self._prop_val != value:
+            self._prop_val = value
+            self.signal_something_happened.emit(str(value))
+
+
+@RPCClient.register_interface(TestInterface)
+class TestClientProxy(TestInterface, RPCClient):
+    """Client Proxy Implementation."""
+
+    def __init__(self, context: zmq.Context, url: str):
+        # Bypass abstract init calls for simplicity in mixin
+        TestInterface.__init__(self)
+        RPCClient.__init__(self, context, url)
+
+
+class BaseRPCTest(unittest.TestCase):
+    def setUp(self):
+        # Use a fresh context for each test to avoid lingering socket states
+        self.context = zmq.Context()
+        self.registry_port = 5555
+        self.registry_addr = "127.0.0.1"
+        self.registry_url = f"tcp://{self.registry_addr}:{self.registry_port}"
+
+        # Suppress noisy logging during tests
+        logging.getLogger('RPC').setLevel(logging.CRITICAL)
+        logging.getLogger('deviceregistry').setLevel(logging.CRITICAL)
+
+    def tearDown(self):
+        gc.collect()
+        print(self.context)
+        self.context.term()
+        self.context = None
+
+    def start_registry(self) -> DeviceRegistry:
+        reg = DeviceRegistry(self.context, addr=self.registry_addr, port=str(self.registry_port))
+        reg.start()
+        time.sleep(0.1)  # Give it a moment to bind
+        return reg
+
+
+# --- Section 1: Core Functionality Tests ---
+
+class TestDeviceRegistryCore(BaseRPCTest):
+
+    def test_registry_lifecycle(self):
+        """Test starting registry, registering a device, and unregistering."""
+        registry = self.start_registry()
+
+        try:
+            # 1. Register Device
+            # We simulate the client side of registration manually to check raw protocol
+            with self.context.socket(zmq.REQ) as socket:
+                socket.connect(self.registry_url)
+
+                # Send Register
+                socket.send_json({
+                    "event": EventType.REGISTER,
+                    "payload": {
+                        "device_type": "camera",
+                        "addr": "tcp://127.0.0.1:9000",
+                        "name": "cam-1",
+                        "overwrite": False
+                    }
+                })
+                reply = socket.recv_json()
+
+                self.assertEqual(reply["event"], EventType.REGISTER_ACK)
+                self.assertEqual(reply["payload"]["name"], "cam-1")
+                uuid_val = reply["payload"]["uuid"]
+                self.assertTrue(uuid_val)
+
+                # 2. Verify Internal State
+                devices = registry.get_devices()
+                self.assertIn("cam-1", devices)
+                self.assertEqual(devices["cam-1"], ("camera", "tcp://127.0.0.1:9000"))
+
+                # 3. Unregister
+                socket.send_json({
+                    "event": EventType.UNREGISTER,
+                    "payload": {"uuid": uuid_val}
+                })
+                reply = socket.recv_json()
+                self.assertEqual(reply["event"], EventType.ACK)
+                self.assertTrue(reply["payload"]["success"])
+
+                # 4. Verify Removal
+                devices = registry.get_devices()
+                self.assertNotIn("cam-1", devices)
+
+        finally:
+            registry.stop()
+            registry.join()
+
+    def test_registry_overwrite_protection(self):
+        """Test registration name conflict handling with and without overwrite."""
+        registry = self.start_registry()
+        try:
+            with self.context.socket(zmq.REQ) as socket:
+                socket.connect(self.registry_url)
+
+                # Register first device
+                socket.send_json({
+                    "event": EventType.REGISTER,
+                    "payload": {"device_type": "A", "addr": "tcp://1.1.1.1", "name": "device", "overwrite": False}
+                })
+                socket.recv_json()
+
+                # Register second device same name, overwrite=False
+                socket.send_json({
+                    "event": EventType.REGISTER,
+                    "payload": {"device_type": "B", "addr": "tcp://2.2.2.2", "name": "device", "overwrite": False}
+                })
+                reply = socket.recv_json()
+
+                # Registry should have renamed the second one
+                name_2 = reply["payload"]["name"]
+                self.assertNotEqual(name_2, "device")
+                self.assertTrue(name_2.startswith("device-"))
+
+                # Register third device, overwrite=True
+                socket.send_json({
+                    "event": EventType.REGISTER,
+                    "payload": {"device_type": "C", "addr": "tcp://3.3.3.3", "name": "device", "overwrite": True}
+                })
+                reply = socket.recv_json()
+
+                # Should take the name "device"
+                self.assertEqual(reply["payload"]["name"], "device")
+
+                # Check that the first device (tcp://1.1.1.1) is gone or replaced
+                current_devices = registry.get_devices()
+                self.assertEqual(current_devices["device"][1], "tcp://3.3.3.3")
+
+        finally:
+            registry.stop()
+            registry.join()
+
+
+class TestRPCProtocol(BaseRPCTest):
+
+    def setUp(self):
+        super().setUp()
+        self.registry = self.start_registry()
+        self.server_port = 9000
+        self.server_url = f"tcp://127.0.0.1:{self.server_port}"
+
+        # Setup Server
+        self.server = TestDevice(self.context, self.server_url)
+        self.server.register_to_registry("test_type", "test_dev", self.registry_url)
+
+        # Run server in thread
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread.daemon = True
+        self.server_thread.start()
+
+        # Give server time to spin up
+        time.sleep(0.2)
+
+    def tearDown(self):
+        self.server.stop_server()
+        self.server_thread.join()
+        self.registry.stop()
+        self.registry.join()
+        del self.server
+        del self.registry
+        super().tearDown()
+
+    def test_rpc_method_call_json(self):
+        """Test basic JSON method call and return value."""
+        client = TestClientProxy(self.context, self.server_url)
+        response = client.echo("Hello World")
+        self.assertEqual(response, "Echo: Hello World")
+
+    def test_rpc_method_call_buffer(self):
+        """Test buffer method call (memoryview transfer)."""
+        client = TestClientProxy(self.context, self.server_url)
+        data, info = client.get_blob()
+
+        self.assertIsInstance(data, (memoryview, bytes))
+        self.assertEqual(bytes(data), b"\xde\xad\xbe\xef")
+        self.assertEqual(info["size"], 4)
+        del client
+
+    def test_rpc_property_get_set(self):
+        """Test property getters and setters."""
+        client = TestClientProxy(self.context, self.server_url)
+
+        # Test Initial Value
+        self.assertEqual(client.test_prop, 0)
+
+        # Test Setter
+        client.test_prop = 42
+
+        # Verify Getter
+        self.assertEqual(client.test_prop, 42)
+
+        # Verify Server Internal State
+        self.assertEqual(self.server._prop_val, 42)
+
+    def test_rpc_signals(self):
+        """Test that server property changes emit signals caught by client."""
+        client = TestClientProxy(self.context, self.server_url)
+
+        # Signal capture
+        received_signals = []
+
+        def signal_handler(val):
+            received_signals.append(val)
+
+        client.signal_something_happened.connect(signal_handler)
+
+        # Trigger signal via property set
+        client.test_prop = 100
+
+        # Allow time for signal propagation (ZMQ is async)
+        time.sleep(0.2)
+
+        self.assertIn("100", received_signals)
+
+    def test_unknown_method_handling(self):
+        """Test client calling a method not exposed by server."""
+        # Using raw socket to simulate malicious/broken client
+        with self.context.socket(zmq.REQ) as s:
+            s.connect(self.server_url)
+            s.send_json({
+                "event": RPCEvents.METHOD_CALL,
+                "method": "non_existent_method",
+                "params": {}
+            })
+            reply = s.recv_json()
+            self.assertFalse(reply["success"])
+            self.assertIn("not implemented", reply["error"])
+
+
+# --- Section 2: Robustness Tests (Expected Failures) ---
+
+class TestRobustness(BaseRPCTest):
+    """
+    Tests scenarios involving connection loss, component restarts, and edge cases.
+    These tests are expected to FAIL with the current implementation.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.registry = self.start_registry()
+        self.server_url = "tcp://127.0.0.1:9001"
+        self.server = TestDevice(self.context, self.server_url)
+        self.server.register_to_registry("test_type", "robust_dev", self.registry_url)
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread.start()
+        time.sleep(0.1)
+
+    def tearDown(self):
+        self.server.stop_server()
+        self.server_thread.join(timeout=1)
+        self.registry.stop()
+        self.registry.join()
+        del self.server
+        del self.registry
+        super().tearDown()
+
+    def test_server_recovers_registration_after_registry_restart(self):
+        """
+        Scenario: Registry crashes and restarts.
+        Expected: Server's 'alive check' fails, detects registry loss, and re-registers itself.
+        Current Behavior: Server logs error but does not re-register.
+        Required Fix: Implement re-registration logic in RPCServer.serve_forever loop when alive_check fails.
+        """
+        # 1. Verify initial registration
+        self.assertIn("robust_dev", self.registry.get_devices())
+
+        # 2. Kill Registry
+        self.registry.stop()
+        self.registry.join()
+
+        # 3. Start New Registry on same port (Simulate restart)
+        # Note: Internal state is lost, so "robust_dev" is unknown to new registry
+        self.registry = self.start_registry()
+        self.assertNotIn("robust_dev", self.registry.get_devices())
+
+        # 4. Wait for Server to heartbeat (alive_timeout=2s in TestDevice)
+        time.sleep(3)
+
+        # 5. Check if Server re-registered
+        # This will fail because RPCServer currently just logs "Check Alive failed"
+        devices = self.registry.get_devices()
+        self.assertIn("robust_dev", devices, "Server failed to re-register after registry restart")
+
+    def test_client_timeout_handling_on_call(self):
+        """
+        Scenario: Server hangs indefinitely during a method call.
+        Expected: Client raises a TimeoutError or specific exception, not just returning False/NoResult.
+        Current Behavior: Client returns False or NoResult object which suppresses the exception context.
+        Required Fix: Client execute() should raise exceptions for timeouts to allow proper try/except flow.
+        """
+        # Mock a server freeze
+        original_method = self.server.echo
+
+        def hanging_method(self, msg):
+            print("A")
+            time.sleep(5)  # Longer than client timeout (1s)
+            print("B")
+            return original_method(msg)
+        self.server.echo = hanging_method
+
+        # Monkey patch the instance method
+        # Note: This is tricky with RPCServer structure, essentially we simulate a timeout
+        # by making the client timeout shorter than server processing.
+
+        client = TestClientProxy(self.context, self.server_url)
+        # We need to manually lower the timeout map in the client for this specific test
+        client._json_methods['echo'] = 100  # 100ms timeout
+
+        with self.assertRaises(TimeoutError, msg="Client did not raise TimeoutError on server hang"):
+            rep = client.echo("Hello")
+            print(rep)
+        del client
+
+    def test_client_reconnect_after_server_restart(self):
+        """
+        Scenario: Server process dies and restarts.
+        Expected: Client detects broken pipe/timeout, reconnects, and succeeds on subsequent calls.
+        Current Behavior: ZMQ REQ/REP gets desynchronized if REP dies in middle. Client inventory is stale.
+        Required Fix: Client needs retry logic and potentially re-fetching inventory/handshake on connection errors.
+        """
+        client = TestClientProxy(self.context, self.server_url)
+        self.assertEqual(client.echo("1"), "Echo: 1")
+
+        # Restart Server
+        self.server.stop_server()
+        self.server_thread.join()
+
+        # Start new server instance on same URL
+        new_server = TestDevice(self.context, self.server_url)
+        # skip registration for speed, just bind port
+        t = threading.Thread(target=new_server.serve_forever)
+        t.start()
+
+        try:
+            # Client calls again.
+            # If the previous socket is stuck awaiting reply, this might hang or fail silently.
+            response = client.echo("2")
+            self.assertEqual(response, "Echo: 2", "Client failed to communicate with restarted server")
+        finally:
+            new_server.stop_server()
+            t.join()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_RPC_registry.py
+++ b/test/test_RPC_registry.py
@@ -1,19 +1,20 @@
 import gc
-import unittest
+import logging
 import threading
 import time
+import unittest
+from typing import Tuple
+
 import zmq
-import logging
-import uuid
-from typing import Tuple, Literal
 
 # Adjust imports based on your actual package structure
-from plantimager.commons.RPC import (
-    RPCClient, RPCServer, RPCSignal, RPCProperty, NoResult, RPCEvents
-)
-from plantimager.commons.deviceregistry import (
-    DeviceRegistry, EventType, ALIVE_TIMEOUT
-)
+from plantimager.commons.RPC import RPCClient
+from plantimager.commons.RPC import RPCEvents
+from plantimager.commons.RPC import RPCProperty
+from plantimager.commons.RPC import RPCServer
+from plantimager.commons.RPC import RPCSignal
+from plantimager.commons.deviceregistry import DeviceRegistry
+from plantimager.commons.deviceregistry import EventType
 
 
 # --- Test Fixtures & Interfaces ---
@@ -352,7 +353,8 @@ class TestRobustness(BaseRPCTest):
         self.registry.join()
 
         # 5. Check if Server stopped
-        self.assertFalse(self.server_thread.is_alive(), "Server's 'alive check' fails, detects registration loss, and exits.")
+        self.assertFalse(self.server_thread.is_alive(),
+                         "Server's 'alive check' fails, detects registration loss, and exits.")
 
     def test_client_timeout_handling_on_call(self):
         """


### PR DESCRIPTION
### Summary

This pull request includes the following changes:
- **Documentation**: Added detailed module- and class-level docstrings in `RPC.py` including parameter descriptions, usage examples, and public interface definitions. Updated code comments for better clarity.
- **Refactoring**: Improved lifecycle management in `RPCServer` and introduced enhancements to `RPCSignal`, such as weak reference handling and improved callable validation. Centralized traceback logging and improved logging consistency.
- **Testing**: Implemented unit tests for `RPC` functionalities, `DeviceRegistry`, and failure scenarios. Tests simulate real-world usage with mock implementations and capture edge cases related to server lifecycle and reconnection.
